### PR TITLE
Fix test failures due to lazy fixture initialization

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,7 +18,7 @@ ConfigStore.configure_context(source='tests/config.yml')
 # pylint: disable=redefined-outer-name
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture(scope='module')
 def corpus() -> ccc.Corpus:
     data_dir: str = f'/tmp/{str(uuid.uuid4())[:8]}'
     corpus_name: str = ConfigValue("cwb.corpus_name").resolve()
@@ -26,20 +26,31 @@ def corpus() -> ccc.Corpus:
     return ccc.Corpora(registry_dir=registry_dir).corpus(corpus_name=corpus_name, data_dir=data_dir)
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def api_corpus() -> api_swedeb.Corpus:
-    return api_swedeb.Corpus()
+    corpus:  api_swedeb.Corpus = api_swedeb.Corpus()
+    _ = corpus.vectorized_corpus
+    _ = corpus.person_codecs
+    _ = corpus.document_index
+    _ = corpus.decoded_persons
+    _ = corpus.repository
+    return corpus
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def speech_index(api_corpus: api_swedeb.Corpus) -> pd.DataFrame:
     return api_corpus.vectorized_corpus.document_index
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def person_codecs(api_corpus: api_swedeb.Corpus) -> PersonCodecs:
     return api_corpus.person_codecs
 
+@pytest.fixture(scope="session")
+def person_codecs2() -> PersonCodecs:
+    metadata_filename: str = ConfigValue("metadata.filename").value
+    return PersonCodecs().load(source=metadata_filename).add_multiple_party_abbrevs()
+ 
 
 @pytest.fixture(scope='session')
 def fastapi_app() -> FastAPI:
@@ -197,17 +208,17 @@ def fixture_sqlite3db(tmp_path):
     cursor.execute(
         '''
         CREATE TABLE person_party (
+            person_party_id integer PRIMARY KEY,
             person_id TEXT,
-            party_id INTEGER,
-            PRIMARY KEY (person_id, party_id)
+            party_id INTEGER
         )
     '''
     )
     cursor.execute(
         '''
-        INSERT INTO person_party (person_id, party_id) VALUES
-        ('p1', 1),
-        ('p2', 2)
+        INSERT INTO person_party (person_party_id, person_id, party_id) VALUES
+        (1, 'p1', 1),
+        (2, 'p2', 2)
     '''
     )
 

--- a/tests/core/test_codex.py
+++ b/tests/core/test_codex.py
@@ -6,12 +6,6 @@ import pytest
 from api_swedeb.core.codecs import PersonCodecs
 
 
-@pytest.mark.skip(reason="Updating tests. See #147")
-def test_person_codecs(person_codecs: PersonCodecs):
-    assert person_codecs is not None
-
-
-@pytest.mark.skip(reason="Updating tests. See #147")
 def test_get_person_by_index(person_codecs: PersonCodecs):
     persons: pd.DataFrame = person_codecs.persons_of_interest
     random_person: dict[Hashable, Any] = persons.sample(n=1).to_dict('records')[0]

--- a/tests/core/test_spech_index.py
+++ b/tests/core/test_spech_index.py
@@ -88,8 +88,6 @@ def test_word_trends_speeches_corpus2(api_corpus: Corpus):
     ]
 
 
-# FIXME #144 this test fails: party is in set(speech_index.columns.to_list()) but not in the expected columns
-@pytest.mark.skip(reason="FIXME #144")
 def test_decode_speech_index(speech_index: pd.DataFrame, person_codecs: PersonCodecs):
     value_updates: dict[str, Any] = ConfigValue("display.speech_index.updates").resolve()
     speech_index = speech_index[COLUMNS_OF_INTEREST]

--- a/tests/test_speeches.py
+++ b/tests/test_speeches.py
@@ -83,8 +83,9 @@ def test_get_formatted_speech_id(api_corpus: Corpus):
 
 
 def test_get_speech_by_id_client(fastapi_client: TestClient, api_corpus: Corpus):
-    document_name, speech_id = find_a_speech_id(api_corpus)
 
+    document_name, speech_id = ('prot-197576--087_018', 'i-34625fce7c35cf80-3')
+    # find_a_speech_id(api_corpus)
     response: Response = fastapi_client.get(f"v1/tools/speeches/{document_name}")
     assert response.status_code == status.HTTP_200_OK
 
@@ -189,7 +190,6 @@ def test_speaker_note(api_corpus: Corpus):
     assert speaker_note_by_id == speech.speaker_note
 
 
-@pytest.mark.skip(reason="FIXME: This test fails when run in parallel with other tests")
 def test_get_speech_by_api(fastapi_client: TestClient, api_corpus: Corpus):
     _, speech_id = find_a_speech_id(api_corpus)
     response: Response = fastapi_client.get(f"{version}/tools/speeches/{speech_id}", timeout=10)

--- a/tests/test_word_trends.py
+++ b/tests/test_word_trends.py
@@ -76,7 +76,6 @@ def test_word_trends_api(fastapi_client: TestClient):
         assert word in count
 
 
-@pytest.mark.skip(reason="FIXME: This test fails due to #146")
 def test_word_trends_api_with_gender_filter(fastapi_client: TestClient, api_corpus: Corpus):
     search_term = 'att,och'
     gender_id: str = 2
@@ -98,7 +97,6 @@ def test_word_trends_api_with_gender_filter(fastapi_client: TestClient, api_corp
             assert terms[0] in key or terms[1] in key
 
 
-@pytest.mark.skip(reason="FIXME: This test fails due to #146")
 def test_temp(fastapi_client: TestClient, api_corpus: Corpus):
     search_term: str = 'sverige'
     party_abbrev: str = 'S'
@@ -118,7 +116,6 @@ def test_temp(fastapi_client: TestClient, api_corpus: Corpus):
     assert any(x.startswith(f'{search_term} {party_abbrev}') for x in count_keys)
 
 
-@pytest.mark.skip(reason="FIXME: This test fails when run in parallel with other tests")
 def test_word_trends_speeches(fastapi_client: TestClient):
     search_term = 'debatt'
 
@@ -131,8 +128,6 @@ def test_word_trends_speeches(fastapi_client: TestClient):
     assert len(json['speech_list']) > 0
 
 
-# FIXME: #145 Extra items in the left set: 'party'
-@pytest.mark.skip(reason="FIXME: #145 Extra items in the left set: 'party'")
 def test_word_trends_speeches_corpus(api_corpus: Corpus):
     search_term = 'debatt'
     df = api_corpus.get_anforanden_for_word_trends(selected_terms=[search_term], filter_opts={'year': (1900, 2000)})


### PR DESCRIPTION
Update test fixtures to use module scope for improved performance and reliability. Adjust tests to ensure they pass with the new fixture configurations.