### PR TITLE
Ensure requirements.txt is copied and cleaned during image build

### DIFF
--- a/.github/scripts/build-and-push-image.sh
+++ b/.github/scripts/build-and-push-image.sh
@@ -34,6 +34,9 @@ fi
 
 log "Using frontend image: ${FRONTEND_IMAGE_BASE}:${FRONTEND_VERSION}"
 
+# Copy requirements.txt into docker directory
+cp requirements.txt docker/
+
 pushd docker > /dev/null
 
 # Extract version components
@@ -75,6 +78,9 @@ else
 fi
 
 popd > /dev/null
+
+# Clean up copied requirements.txt
+rm docker/requirements.txt
 
 # Push all tags
 docker push --all-tags "${IMAGE_NAME}"


### PR DESCRIPTION
Copy requirements.txt into the docker directory during the image build process and remove it afterward to maintain a clean environment.