### PR TITLE
fix: allow workaround to run when /app/public is read-only

### DIFF
--- a/docker/download-frontend.sh
+++ b/docker/download-frontend.sh
@@ -100,19 +100,14 @@ fi
 log "Creating assets directory if needed: $ASSETS_DIR"
 mkdir -p "$ASSETS_DIR"
 
-# Check if assets directory is writable
-if [ ! -w "$ASSETS_DIR" ]; then
-    error_exit "Assets directory is not writable: $ASSETS_DIR (check permissions and volume mounts)"
-fi
-
-# Test write access with a temporary file
+# Check if assets directory is writable (warning only, workaround will handle it)
 TEST_FILE="${ASSETS_DIR}/.write_test"
 if ! touch "$TEST_FILE" 2>/dev/null; then
-    error_exit "Cannot write to assets directory: $ASSETS_DIR (read-only filesystem or permission denied)"
+    log "WARNING: Assets directory may not be writable (will use /tmp extraction workaround if needed)"
+else
+    rm -f "$TEST_FILE"
+    log "Assets directory is writable"
 fi
-rm -f "$TEST_FILE"
-
-log "Assets directory is writable"
 
 # Check for local fallback tarball
 FALLBACK_TARBALL="/data/dist/${TARBALL}"


### PR DESCRIPTION
## Critical Bugfix

Fixes a critical bug in the read-only filesystem workaround that prevented containers from starting.

## Problem

The previous fix (commit c010c71) added a write permission check that called `error_exit` if `/app/public` was not writable. This prevented the script from ever reaching the `/tmp` extraction workaround code, causing containers to fail immediately with:

```
ERROR: Assets directory is not writable: /app/public (check permissions and volume mounts)
```

## Solution

Changed the early write check from `error_exit` to a warning only. Now the script:
1. Warns if directory may not be writable
2. Continues to tar extraction
3. Lets tar fail naturally if directory is read-only
4. Automatically triggers `/tmp` extraction workaround
5. Copies files from `/tmp` to `/app/public`

## Impact

Containers will now start successfully on Podman/SELinux/overlay fs configurations where `/app/public` appears read-only during the initial check.

## Testing

After this fix, the logs should show:
```
WARNING: Assets directory may not be writable (will use /tmp extraction workaround if needed)
...
Attempting workaround: extract to /tmp and copy...
Successfully extracted to temporary directory
Successfully copied files to /app/public
```

## Changes

- `docker/download-frontend.sh`: Changed write permission check from error to warning

## Priority

**HIGH** - Current staging image cannot start due to this bug