### PR TITLE
Fix ticketed speech downloads and namespace frontend prerelease tags

### DIFF
--- a/api_swedeb/api/services/download_service.py
+++ b/api_swedeb/api/services/download_service.py
@@ -206,6 +206,35 @@ class DownloadService:
     def __init__(self, compression_strategy: CompressionStrategy | None = None) -> None:
         self.compression_strategy = compression_strategy or ZipCompressionStrategy()
 
+    def create_single_file_zip_stream(
+        self,
+        *,
+        archive_filename: str,
+        content: bytes,
+    ) -> Callable[[], Generator[bytes, None, None]]:
+        """Return a generator function that yields a ZIP archive with one file."""
+
+        def _generate() -> Generator[bytes, None, None]:
+            writer = _StreamingBuffer()
+
+            with zipfile.ZipFile(
+                writer,
+                mode="w",
+                compression=zipfile.ZIP_DEFLATED,
+                compresslevel=1,
+                allowZip64=True,
+            ) as zf:
+                zf.writestr(archive_filename, content)
+                chunk = writer.pop()
+                if chunk:
+                    yield chunk
+
+            chunk = writer.pop()
+            if chunk:
+                yield chunk
+
+        return _generate
+
     def create_stream(
         self,
         search_service: SearchService,

--- a/api_swedeb/api/v1/endpoints/tool_router.py
+++ b/api_swedeb/api/v1/endpoints/tool_router.py
@@ -322,31 +322,29 @@ async def download_word_trend_speeches(
     ticket_id: str,
     file_format: str = Query("csv", alias="format", description="Download format: csv or json"),
     wt_speeches_ticket_service: WordTrendSpeechesTicketService = Depends(get_word_trend_speeches_ticket_service),
+    download_service: DownloadService = Depends(get_download_service),
     result_store: ResultStore = Depends(get_result_store),
 ) -> StreamingResponse:
     """Download the full speech list from a ready word trend speeches ticket."""
-    import io
-
     try:
         data = wt_speeches_ticket_service.get_full_artifact(ticket_id, result_store)
     except ResultStoreNotFound as exc:
         raise HTTPException(status_code=404, detail="Ticket not found or expired") from exc
 
-    if file_format == "json":
-        content = data.to_json(orient="records", force_ascii=False)
-        return StreamingResponse(
-            iter([content]),
-            media_type="application/json",
-            headers={"Content-Disposition": f'attachment; filename="word_trend_speeches_{ticket_id}.json"'},
-        )
+    inner_filename = f"word_trend_speeches_{ticket_id}.{file_format}"
 
-    # Default: CSV
-    buf = io.StringIO()
-    data.to_csv(buf, index=False)
+    if file_format == "json":
+        content = data.to_json(orient="records", force_ascii=False).encode("utf-8")
+    else:
+        content = data.to_csv(index=False).encode("utf-8")
+
     return StreamingResponse(
-        iter([buf.getvalue()]),
-        media_type="text/csv",
-        headers={"Content-Disposition": f'attachment; filename="word_trend_speeches_{ticket_id}.csv"'},
+        download_service.create_single_file_zip_stream(
+            archive_filename=inner_filename,
+            content=content,
+        )(),
+        media_type="application/zip",
+        headers={"Content-Disposition": f'attachment; filename="word_trend_speeches_{ticket_id}.zip"'},
     )
 
 
@@ -551,11 +549,10 @@ async def get_speeches_page(
 async def download_speeches_by_ticket(
     ticket_id: str,
     file_format: str = Query("csv", alias="format", description="Download format: csv or json"),
+    download_service: DownloadService = Depends(get_download_service),
     result_store: ResultStore = Depends(get_result_store),
 ) -> StreamingResponse:
     """Download the full speech list from a ready speeches ticket."""
-    import io
-
     try:
         ticket: TicketMeta = result_store.require_ticket(ticket_id)
     except ResultStoreNotFound as exc:
@@ -577,21 +574,20 @@ async def download_speeches_by_ticket(
     except Exception as exc:
         raise HTTPException(status_code=404, detail="Ticket artifact not found or expired") from exc
 
-    if file_format == "json":
-        content = data.to_json(orient="records", force_ascii=False)
-        return StreamingResponse(
-            iter([content]),
-            media_type="application/json",
-            headers={"Content-Disposition": f'attachment; filename="speeches_{ticket_id}.json"'},
-        )
+    inner_filename = f"speeches_{ticket_id}.{file_format}"
 
-    # Default: CSV
-    buf = io.StringIO()
-    data.to_csv(buf, index=False)
+    if file_format == "json":
+        content = data.to_json(orient="records", force_ascii=False).encode("utf-8")
+    else:
+        content = data.to_csv(index=False).encode("utf-8")
+
     return StreamingResponse(
-        iter([buf.getvalue()]),
-        media_type="text/csv",
-        headers={"Content-Disposition": f'attachment; filename="speeches_{ticket_id}.csv"'},
+        download_service.create_single_file_zip_stream(
+            archive_filename=inner_filename,
+            content=content,
+        )(),
+        media_type="application/zip",
+        headers={"Content-Disposition": f'attachment; filename="speeches_{ticket_id}.zip"'},
     )
 
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -36,9 +36,13 @@ RUN mkdir -p public && \
 ARG FRONTEND_VERSION=staging
 RUN set -ex; \
     if [ -n "${FRONTEND_VERSION}" ]; then \
-        echo "Downloading frontend version: ${FRONTEND_VERSION}"; \
+        case "${FRONTEND_VERSION}" in \
+            staging|test) FRONTEND_RELEASE_TAG="frontend-${FRONTEND_VERSION}" ;; \
+            *) FRONTEND_RELEASE_TAG="${FRONTEND_VERSION}" ;; \
+        esac; \
+        echo "Downloading frontend version: ${FRONTEND_VERSION} from release tag: ${FRONTEND_RELEASE_TAG}"; \
         wget -O /tmp/frontend.tar.gz \
-            "https://github.com/humlab-swedeb/swedeb_frontend/releases/download/${FRONTEND_VERSION}/frontend-${FRONTEND_VERSION}.tar.gz"; \
+            "https://github.com/humlab-swedeb/swedeb_frontend/releases/download/${FRONTEND_RELEASE_TAG}/frontend-${FRONTEND_VERSION}.tar.gz"; \
         tar -xzf /tmp/frontend.tar.gz -C /app/public; \
         rm /tmp/frontend.tar.gz; \
         echo "${FRONTEND_VERSION}" > /app/public/.frontend_version; \

--- a/docker/README.md
+++ b/docker/README.md
@@ -41,7 +41,7 @@ At runtime:
 - [main.py](main.py) exposes the FastAPI app for `uvicorn`.
 
 
-**Note:** Frontend is bundled into the image during build. This eliminates runtime download complexity, works with ReadOnly containers, and ensures consistent deployments. Frontend version is controlled via the `FRONTEND_VERSION` build argument (defaults to `staging`).
+**Note:** Frontend is bundled into the image during build. This eliminates runtime download complexity, works with ReadOnly containers, and ensures consistent deployments. Frontend version is controlled via the `FRONTEND_VERSION` build argument (defaults to `staging`). For compatibility, `FRONTEND_VERSION=staging|test` now resolves to the frontend release tags `frontend-staging|frontend-test` while keeping the asset names `frontend-staging.tar.gz|frontend-test.tar.gz`.
 
 ## GitHub Actions Workflow
 

--- a/docker/quadlets/swedeb-staging-app.container
+++ b/docker/quadlets/swedeb-staging-app.container
@@ -20,7 +20,7 @@ ContainerName=swedeb-api-staging
 Network=swedeb-staging-app.network
 
 # Ports MUST be hard-coded. This maps host port 8098 to container port 8098.
-PublishPort=127.0.0.1:8098:8092
+PublishPort=127.0.0.1:8098:8098
 
 # Volume paths MUST be hard-coded and absolute.
 # We use the %h specifier to correctly point to /srv/swedeb_staging.

--- a/docker/test-network.sh
+++ b/docker/test-network.sh
@@ -112,7 +112,7 @@ test_http_connectivity() {
 }
 
 test_github_download() {
-    local url="https://github.com/humlab-swedeb/swedeb_frontend/releases/download/staging/frontend-staging.tar.gz"
+    local url="https://github.com/humlab-swedeb/swedeb_frontend/releases/download/frontend-staging/frontend-staging.tar.gz"
     
     echo -n "Testing GitHub tarball download... "
     if curl -L --fail --connect-timeout 10 --max-time 30 -o /dev/null "$url" 2>/dev/null; then

--- a/docs/archive/RECENT_IMPROVEMENTS.md
+++ b/docs/archive/RECENT_IMPROVEMENTS.md
@@ -1,0 +1,325 @@
+# Recent Improvements
+
+Snapshot date: 2026-04-23
+
+This document summarizes the major improvements we have made recently across `swedeb-api` and `swedeb_frontend`, with related backend and frontend changes grouped together.
+
+## Executive Summary
+
+Over the last couple of weeks, the main change across both repositories has been a shift from large synchronous result delivery to ticket-based, paginated workflows for expensive searches. On the backend, this introduced server-side result caching, async ticket execution, paged KWIC and word-trend speech retrieval, more consistent speech download handling, and follow-up worker and staging stability fixes. On the frontend, the matching work replaced client-heavy result handling with server-side pagination, improved download flows, and tightened error handling around ticket expiry and loading states.
+
+Performance work was the second major theme. In `swedeb-api`, word-trends execution was reduced substantially for common-word queries, DTM grouping and corpus-loading behavior were optimized, and unused Penelope/DTM code was removed or folded into the active runtime. In `swedeb_frontend`, the word-trends page was reworked to use parallel requests and progressive rendering, which reduced perceived wait time and made the page usable earlier during long-running searches.
+
+The codebase was also cleaned up structurally. The backend moved further toward explicit services, thinner routers, clearer dependency wiring, and better separation between active and legacy code paths. The frontend simplified store/component responsibilities, consolidated ticket-aware table behavior, and cleaned up analytics and build workflow logic. In parallel, both repositories gained stronger operational support through release and staging workflow work, and the backend in particular added a much broader automated test surface to support these architectural changes.
+
+## How this summary was compiled
+
+This write-up is based on three sources:
+
+1. The current `CHANGELOG.md` files in both repositories
+2. `origin/main..origin/staging` branch diffs and recent commit history
+3. Recent GitHub issues and pull requests, especially work updated since 2026-04-09
+
+One important caveat: the changelogs do not yet capture most of the April 2026 work. The branch diffs and issue/PR history are therefore the more accurate source for the last couple of weeks.
+
+## Scope at a glance
+
+- `swedeb-api`: `origin/main..origin/staging` currently spans a very large backend modernization wave, including API restructuring, ticketed async workflows, performance work, deployment hardening, documentation expansion, and extensive new tests.
+- `swedeb_frontend`: `origin/main..origin/staging` captures a concentrated UI/data-flow update focused on ticket-based pagination, better progressive loading, PDF navigation, release workflow cleanup, and store/component simplification.
+
+## 1. Ticketed search workflows and paginated result delivery
+
+This has been one of the biggest joint improvements across backend and frontend.
+
+### Backend
+
+The API moved several heavy result flows away from large synchronous responses and toward ticket-based, artifact-backed workflows:
+
+- Paged KWIC results via a server-side result cache and ticket lifecycle
+- Async, paged word-trend speeches results
+- Async speeches queries with page-by-page retrieval
+- Reuse of cached speech IDs and manifest metadata when downloading speeches from ticketed results
+- ZIP delivery consistency for ticketed speech exports, including the recent fix to wrap CSV/JSON ticket downloads in ZIP archives
+
+Key related issues and PRs include:
+
+- `swedeb-api#267`: paged KWIC results via ticket-based server-side cache
+- `swedeb-api#304`: paged word-trend speeches via async ticket flow
+- `swedeb-api#263`, `#264`, `#265`, `#266`: speech download alignment, deduplication, manifest metadata, and download workflow cleanup
+- PR `#268`: Paged KWIC Results via Server-side cache
+- PR `#305`: Paged word trends speeches
+- PR `#307`: Introduce async speech worker flow
+- PR `#311`: Worker stability fixes
+- `swedeb-api#312`: ZIP ticketed speech downloads
+
+Technically, this work introduced or expanded:
+
+- `ResultStore` and ticket lifecycle management
+- dedicated ticket services for KWIC and word-trend speeches
+- artifact-backed pagination over Feather/Arrow output
+- better separation between routing, service logic, and cached result delivery
+- more predictable download behavior across tools
+
+### Frontend
+
+The frontend was updated in parallel to consume those ticketed flows instead of trying to hold everything client-side:
+
+- KWIC now uses ticket submission, polling, and server-side pagination
+- Speeches search now uses ticket-based paging and download actions
+- Word-trends speech tables now use the new paged ticket flow
+- Download buttons were aligned with the new ticket endpoints
+- Pagination, expiry, and loading/error states were hardened
+
+Key related issues and PRs include:
+
+- `swedeb_frontend#164`: optimize word trends page loading and rendering performance
+- `swedeb_frontend#165`: per-tab loading indicators for word trends
+- `swedeb_frontend#166`: pagination fails silently when tickets expire
+- `swedeb_frontend#167`: expired ticket shows "no results" instead of expiration message
+- `swedeb_frontend#170`: prevent false no-results flash in ticketed result tables
+- PR `#156`: add pagination workflow / ticketed request-response flow
+- PR `#168`: implement server-side pagination for speeches
+- PR `#169`: improve performance for word trends
+- PR `#171`: fix false no-results flash in ticketed result tables
+
+The net effect is that the browser no longer needs to materialize or sort huge result sets locally for these tools.
+
+## 2. Performance improvements and scalability work
+
+The other dominant theme has been performance, especially for large corpora and common-word searches.
+
+### Backend
+
+#### Word trends
+
+`swedeb-api#302` optimized word trends for small word lists by slicing the vector space before grouping. For common words such as `att`, this reduced query time dramatically.
+
+Important result from the issue write-up:
+
+- Before: 30+ seconds for a common-word HTTP query
+- After: around 3 seconds
+
+#### DTM and corpus processing
+
+Several recent issues and PRs focused on DTM loading, grouping, and tree-shaking of unused corpus code:
+
+- `swedeb-api#301`: DTM corpus loading optimization
+- `swedeb-api#282` to `#299`: grouping, naming, type conversion, vocabulary matching, and removal of unnecessary materialization
+- PR `#303`: optimize DTM performance and processing
+- PR `#277`: refactor and clean up deprecated/unused Penelope-related code
+
+Supporting repo notes from the recent work:
+
+- The biggest corpus-loading gain came from eager startup loading rather than replacing the NPZ format
+- DTM grouping was optimized to reduce allocations and improve large-scale grouping performance by roughly `1.3x` to `2.4x`, depending on dataset size
+- Unused DTM and Penelope modules were removed or folded into `api_swedeb/core`, which reduced indirection and improved maintainability
+
+#### KWIC and worker stability
+
+Performance work also targeted KWIC execution and runtime stability:
+
+- `swedeb-api#254`: multiprocessing KWIC issues
+- PR `#278`: Celery and Redis integration work
+- PR `#279`: KWIC performance optimization
+- PR `#311`: worker stability fixes
+
+This work improved not only throughput, but also how the API behaves under long-running or concurrent requests.
+
+### Frontend
+
+The frontend improvements focused on perceived speed and progressive rendering, especially on the Word Trends page.
+
+From `swedeb_frontend#164` and `#165`:
+
+- trends and speeches requests were moved from sequential to parallel execution
+- chart/table content can appear before speeches finish loading
+- loading indicators were split by tab instead of blocking the whole page
+- chart reactivity and animation delays were cleaned up
+
+The practical result is that the page now feels faster even when the backend is still processing the slower speech retrieval part.
+
+## 3. Architecture cleanup, refactoring, and tree-shaking
+
+Much of the recent work was not just feature delivery, but simplification of the codebase.
+
+### Backend
+
+The backend saw a large structural cleanup:
+
+- move toward an app-scoped container and direct service injection
+- thinner routers and clearer service boundaries
+- removal of pass-through utility wrappers in favor of dedicated services
+- migration of active runtime logic into `api_swedeb/api/` and `api_swedeb/core/`
+- legacy ZIP-backed lookup paths pushed into `api_swedeb/legacy/`
+- introduction of prebuilt speech index / repository-oriented runtime paths
+- consolidation of DTM-related logic under `api_swedeb/core/dtm/`
+
+The `origin/main..origin/staging` diff shows this especially clearly:
+
+- many old `api/utils/*` wrappers were removed
+- new service modules were added for corpus loading, metadata, search, n-grams, KWIC, word trends, downloads, and ticket handling
+- many tests were added at service, endpoint, integration, regression, profiling, and workflow layers
+
+This is also where the tree-shaking work landed most visibly: removing or isolating unused Penelope/DTM code and replacing broad dependencies with locally-owned runtime paths.
+
+### Frontend
+
+The frontend cleanup was smaller in file count but still important:
+
+- result logic became more store-driven and ticket-aware
+- speech table responsibilities were split into clearer components
+- metadata and download flows were cleaned up
+- analytics logic was extracted into a composable
+- release/build responsibilities were simplified in CI/CD scripts
+
+Key items include:
+
+- `swedeb_frontend#161`: refactor gtag event resolution
+- extraction and cleanup of ticket-aware table/store logic
+- dependency and build tooling cleanup from the major package update branch and follow-up fixes
+
+## 4. PDF and document navigation improvements
+
+Another cross-cutting feature area was pagewise PDF viewing.
+
+### Backend
+
+- PR `#290`: add page range endpoint and related backend support
+
+### Frontend
+
+- PR `#163`: add `PdfPageWise` component and route
+- better navigation between API data and PDF pages
+- improvements to related PDF UX and link behavior
+
+This work gives users a more direct bridge between search hits and the scanned source material.
+
+## 5. Speech download improvements
+
+Speech download behavior was tightened up significantly across the stack.
+
+### Backend
+
+The backend now has a clearer download story:
+
+- `POST /speeches/download` supports filtered downloads and ticket-based downloads using cached speech IDs
+- manifest metadata is generated and included in ZIPs
+- speech IDs are deduplicated before archive generation
+- recent ticketed CSV/JSON download endpoints now return ZIP streams for consistency
+
+Key issues:
+
+- `swedeb-api#263`, `#264`, `#265`, `#266`, `#312`
+
+### Frontend
+
+The frontend matched that work by:
+
+- sending download requests through the newer POST-based download path where appropriate
+- ensuring full result downloads are not limited to the current visible page
+- wiring ticket-based CSV/JSON exports into the refreshed tables
+
+This area is a good example of backend/frontend changes moving in lockstep rather than independently.
+
+## 6. Deployment, staging, and operational hardening
+
+The recent work also improved how the system is built, deployed, and tested outside local development.
+
+### Backend
+
+`swedeb-api` saw a major operations and runtime hardening wave:
+
+- new staging and test workflows
+- improved Docker and Podman handling
+- Podman Quadlet configuration for staging services
+- private network configuration for staging containers
+- Celery/Redis deployment fixes and synchronization work
+- much stronger operational documentation
+
+Key PRs include:
+
+- `#309`: Podman Quadlet configuration
+- `#311`: worker stability fixes
+- `#280`: local container workflow documentation
+- `#281`: Dockerfile and dependency cleanup
+
+The repository now also has significantly expanded documentation in:
+
+- `docs/DESIGN.md`
+- `docs/DEVELOPMENT.md`
+- `docs/OPERATIONS.md`
+- `docs/TESTING.md`
+
+### Frontend
+
+The frontend CI/release pipeline also moved forward:
+
+- deprecation of older container-build assumptions in favor of asset/tarball flows
+- cleanup of build-assets and release workflow behavior
+- staging/test naming simplification
+- dependency upgrades and follow-up fixes
+- clearer CI/CD documentation
+
+Key PRs/issues include:
+
+- PR `#159`: major frontend package updates
+- `swedeb_frontend#158`: deprecate Docker image builds
+- `swedeb_frontend#157`: package upgrades
+
+## 7. Test coverage and engineering discipline
+
+Both repos gained a substantial amount of new verification around the new architecture.
+
+### Backend
+
+This is especially visible in `swedeb-api`, where the diff shows a very large expansion of:
+
+- endpoint tests
+- service tests
+- integration tests
+- profiling scripts
+- regression suites
+- workflow and prebuilt-index tests
+
+This testing growth matters because many of the recent changes were architectural and performance-related, not just UI polish.
+
+### Frontend
+
+The frontend work was validated more through linting, staged issue/PR flow, and component/store behavior updates than through an automated test suite, but the recent changes clearly show improved discipline in:
+
+- tighter store error handling
+- clearer loading-state management
+- more explicit separation of component responsibilities
+
+## Backend and frontend changes that clearly belong together
+
+These are the strongest paired stories across the two repositories:
+
+1. **Paged search results**
+   Backend added ticket/result-store infrastructure; frontend moved KWIC, speeches, and word-trend speech tables onto it.
+
+2. **Word trends performance**
+   Backend optimized word-trend computation; frontend switched to parallel/progressive rendering so users see the gain.
+
+3. **Speech downloads**
+   Backend aligned download endpoints, manifests, deduplication, and ZIP streaming; frontend updated download actions and avoided current-page-only exports.
+
+4. **PDF navigation**
+   Backend added page-range support; frontend delivered a pagewise PDF viewer route and UI.
+
+5. **Operational maturity**
+   Backend hardened staging workers and container flows; frontend simplified its release/build pipeline to match the evolving deployment model.
+
+## Bottom line
+
+The last couple of weeks were not a small bug-fix phase. They were a broad consolidation phase across both repositories:
+
+- heavy result flows moved from synchronous delivery to ticketed, paginated workflows
+- large performance problems in word trends, KWIC, and DTM processing were addressed
+- the backend architecture became more service-oriented and easier to reason about
+- old or unused runtime code was removed or archived
+- speech downloads became more consistent and robust
+- frontend UX now reflects backend progress more accurately through progressive loading and better error handling
+- deployment, staging, docs, and tests were all upgraded alongside the feature work
+
+This means the system is now not just faster, but also more maintainable, more observable, and more consistent across backend and frontend.

--- a/docs/archive/RECENT_SWEDEB_IMPROVMENTS.md
+++ b/docs/archive/RECENT_SWEDEB_IMPROVMENTS.md
@@ -1,0 +1,190 @@
+# Recent Swedeb Improvements
+
+Snapshot date: 2026-04-23
+
+This document combines the recent improvement summaries from `swedeb-api` and `swedeb_frontend` into one cross-repository overview.
+
+## Executive Summary
+
+Over the last couple of weeks, the main change across Swedeb has been a move from large synchronous result delivery to ticket-based, paginated workflows for expensive searches. The backend introduced server-side result caching, async ticket execution, paged KWIC and word-trend speech retrieval, more consistent speech-download handling, and follow-up worker and staging stability fixes. The frontend was updated to consume those flows through server-side pagination, improved download behavior, and more explicit handling of loading, expiry, and error states.
+
+Performance was the second major theme. In `swedeb-api`, word-trend execution for common-word searches was reduced substantially, DTM grouping and corpus-loading behavior were optimized, and unused Penelope/DTM code was removed or folded into the active runtime. In `swedeb_frontend`, the word-trends page was reworked to use parallel requests and progressive rendering, reducing perceived wait time and making the page usable earlier during long-running searches.
+
+The codebase was also cleaned up structurally. The backend moved further toward explicit services, thinner routers, clearer dependency wiring, and a cleaner split between active and legacy paths. The frontend simplified store/component responsibilities, consolidated ticket-aware table behavior, and cleaned up analytics and build workflow logic. In parallel, both repositories gained stronger operational support through release and staging work, and the backend added a much broader automated test surface to support the architectural changes.
+
+## Source Basis
+
+This summary is based on:
+
+1. `RECENT_IMPROVEMENTS.md` in `swedeb-api`
+2. `RECENT_IMPROVEMENTS.md` in `swedeb_frontend`
+3. The underlying evidence already compiled for those documents:
+   `CHANGELOG.md`, `origin/main..origin/staging` diffs, recent commit history, and relevant GitHub issues and pull requests
+
+As noted in the underlying summaries, the changelogs do not yet reflect most of the April 2026 work. The branch diffs and issue/PR history therefore provide the more accurate view for the last couple of weeks.
+
+## Combined View
+
+### 1. Search and Result Delivery
+
+The largest shared change was the introduction of ticket-based search workflows for expensive result sets.
+
+On the backend, this included:
+
+- paged KWIC results via a server-side result cache
+- async, paged word-trend speeches retrieval
+- async speeches queries with page-based retrieval
+- reuse of cached speech IDs and manifest metadata when downloading from ticketed results
+- ZIP-based delivery consistency for ticketed speech exports
+
+On the frontend, this included:
+
+- KWIC ticket submission, polling, and server-side pagination
+- ticket-based speeches paging and downloads
+- word-trend speech tables wired to paged ticket flows
+- better handling of ticket expiry during pagination
+- improved loading and empty-state transitions in ticketed result tables
+
+The main system-level outcome is that the browser no longer needs to materialize and sort large result sets locally for these tools.
+
+### 2. Performance and Scalability
+
+The next major area was performance work across both the backend runtime and the user-facing experience.
+
+Backend improvements included:
+
+- faster word-trend execution for small word lists by slicing the vector space before grouping
+- DTM grouping improvements that reduced allocation churn and improved large-scale grouping performance
+- corpus-loading improvements that shifted the main gain from storage-format experiments to eager loading at startup
+- KWIC and worker stability improvements aimed at long-running and concurrent request behavior
+
+Frontend improvements included:
+
+- parallel API requests on the Word Trends page
+- progressive rendering so chart/table content can appear before speeches finish loading
+- split loading states by tab instead of blocking the whole view
+- cleanup of chart reactivity and rendering delays
+
+The combined effect is both lower backend processing time and better perceived responsiveness in the UI.
+
+### 3. Architecture Cleanup and Tree-Shaking
+
+Recent work also simplified the internal structure of the system.
+
+Backend cleanup included:
+
+- more explicit service-based architecture
+- thinner routers and clearer dependency injection
+- removal of pass-through utility wrappers
+- migration of active runtime logic into `api_swedeb/api/` and `api_swedeb/core/`
+- isolation of older fallback logic into `api_swedeb/legacy/`
+- consolidation of DTM-related logic under the active core runtime
+- removal or deactivation of unused Penelope/DTM paths
+
+Frontend cleanup included:
+
+- clearer store ownership for ticket-aware result flows
+- cleanup of speech-table responsibilities
+- simplified download and metadata flows
+- extraction of analytics logic into a composable
+- build/release workflow cleanup following package and CI changes
+
+This was not just feature growth; it was active removal of complexity and dead weight.
+
+### 4. Speech Downloads
+
+Speech download behavior was tightened across both repositories.
+
+Backend changes included:
+
+- support for filtered and ticket-based speech ZIP downloads through the newer download path
+- manifest metadata included in ZIP archives
+- speech ID deduplication before archive generation
+- recent alignment of ticketed CSV/JSON downloads so they now stream ZIP responses for consistency
+
+Frontend changes included:
+
+- use of the newer POST-based speech download flow where appropriate
+- fixes so downloads are not limited to the current visible page
+- alignment of ticket-based export actions with the new backend contract
+
+This area is a clear example of backend/frontend work being delivered as one coherent feature set.
+
+### 5. PDF and Navigation Improvements
+
+Another shared improvement was better movement between search results and scanned source documents.
+
+Backend support was extended with page-range functionality, while the frontend introduced a pagewise PDF viewer route and supporting UI. Together, those changes improved the connection between API-derived result context and PDF navigation.
+
+### 6. Deployment, Staging, and Operations
+
+Both repositories saw changes that improved build, release, and deployment handling.
+
+Backend operations work included:
+
+- staging and test workflow updates
+- improved Docker and Podman support
+- Quadlet configuration for staging services
+- network and worker fixes for Celery/Redis-based processing
+- substantially expanded operational and development documentation
+
+Frontend operations work included:
+
+- simplification of release/build logic around assets and tarball flows
+- cleanup of CI/CD workflow behavior
+- package upgrade follow-up fixes
+- clearer CI/CD documentation
+
+Taken together, these changes improved not only runtime behavior but also the path to deploying and validating that runtime.
+
+### 7. Testing and Engineering Discipline
+
+The backend gained a much broader automated test surface, including:
+
+- endpoint tests
+- service tests
+- integration tests
+- regression suites
+- profiling scripts
+- workflow and prebuilt-index tests
+
+The frontend changes were validated more through store/component behavior, linting, and staged issue/PR workflows than through a large automated UI test suite, but the recent work still shows better discipline around:
+
+- error handling
+- loading-state modeling
+- separation of concerns between stores and components
+
+## Paired Changes Across Backend and Frontend
+
+The clearest backend/frontend pairings are:
+
+1. **Paged search results**
+   Backend added ticket/result-store infrastructure; frontend moved KWIC, speeches, and word-trend speech tables onto it.
+
+2. **Word-trends performance**
+   Backend reduced compute time; frontend surfaced the improvement through parallel and progressive rendering.
+
+3. **Speech downloads**
+   Backend aligned manifests, deduplication, and ZIP streaming; frontend aligned download actions and full-result export behavior.
+
+4. **PDF navigation**
+   Backend added page-range support; frontend added the pagewise PDF route and UI.
+
+5. **Operational maturity**
+   Backend hardened staging workers and containers; frontend simplified its release/build pipeline to match the updated deployment model.
+
+## Overall Assessment
+
+This was not a narrow bug-fix period. It was a broader consolidation phase across Swedeb.
+
+The main results were:
+
+- expensive result flows moved from synchronous delivery to ticketed, paginated workflows
+- performance bottlenecks in word trends, KWIC, DTM processing, and UI rendering were addressed
+- the backend became more service-oriented and easier to reason about
+- unused or obsolete runtime code was removed or isolated
+- speech download behavior became more consistent across tools
+- frontend UX now reflects backend progress more accurately through progressive loading and clearer failure handling
+- deployment, staging, documentation, and test coverage all improved alongside the feature work
+
+The combined effect is a system that is faster, more maintainable, more consistent between backend and frontend, and easier to operate.

--- a/tests/api_swedeb/api/endpoints/test_tool_router.py
+++ b/tests/api_swedeb/api/endpoints/test_tool_router.py
@@ -1,7 +1,9 @@
 """Unit tests for uncovered tool router endpoints."""
 
 import asyncio
+import io
 import json
+import zipfile
 from datetime import UTC, datetime
 from unittest.mock import MagicMock, patch
 
@@ -12,6 +14,7 @@ from fastapi.responses import JSONResponse, StreamingResponse
 
 from api_swedeb.api.services.result_store import ResultStoreNotFound, ResultStorePendingLimitError
 from api_swedeb.api.v1.endpoints.tool_router import (
+    download_speeches_by_ticket,
     download_word_trend_speeches,
     get_kwic_results,
     get_kwic_ticket_results,
@@ -30,9 +33,11 @@ from api_swedeb.api.v1.endpoints.tool_router import (
     submit_kwic_query,
     submit_word_trend_speeches_query,
 )
+from api_swedeb.api.services.download_service import DownloadService
 from api_swedeb.core.speech import Speech
 from api_swedeb.schemas.kwic_schema import KWICPageResult, KWICQueryRequest, KWICTicketStatus
 from api_swedeb.schemas.ngrams_schema import NGramResult, NGramResultItem
+from api_swedeb.schemas.speeches_schema import SpeechesTicketStatus
 from api_swedeb.schemas.sort_order import SortOrder
 from api_swedeb.schemas.speeches_schema import SpeechesResult, SpeechesResultItem
 from api_swedeb.schemas.word_trends_schema import (
@@ -756,38 +761,59 @@ class TestWordTrendSpeechesTicketEndpoints:
         wt_service.get_full_artifact.return_value = pd.DataFrame(
             [{"year": 1970, "name": "A. Svensson", "party_abbrev": "S", "document_name": "prot-1970--1"}]
         )
+        download_service = DownloadService()
 
         result = asyncio.run(
             download_word_trend_speeches(
                 ticket_id="wt-ticket-1",
                 file_format="csv",
                 wt_speeches_ticket_service=wt_service,
+                download_service=download_service,
                 result_store=MagicMock(),
             )
         )
 
+        body = asyncio.run(_collect_streaming_response(result))
+
         assert isinstance(result, StreamingResponse)
-        assert result.media_type == "text/csv"
-        assert "word_trend_speeches_wt-ticket-1.csv" in result.headers["content-disposition"]
+        assert result.media_type == "application/zip"
+        assert "word_trend_speeches_wt-ticket-1.zip" in result.headers["content-disposition"]
+        with zipfile.ZipFile(io.BytesIO(body), "r") as archive:
+            assert archive.namelist() == ["word_trend_speeches_wt-ticket-1.csv"]
+            assert (
+                archive.read("word_trend_speeches_wt-ticket-1.csv")
+                .decode("utf-8")
+                .startswith("year,name,party_abbrev,document_name")
+            )
 
     def test_download_returns_json_streaming_response_when_requested(self):
         wt_service = MagicMock()
         wt_service.get_full_artifact.return_value = pd.DataFrame(
             [{"year": 1970, "name": "A. Svensson", "party_abbrev": "S", "document_name": "prot-1970--1"}]
         )
+        download_service = DownloadService()
 
         result = asyncio.run(
             download_word_trend_speeches(
                 ticket_id="wt-ticket-1",
                 file_format="json",
                 wt_speeches_ticket_service=wt_service,
+                download_service=download_service,
                 result_store=MagicMock(),
             )
         )
 
+        body = asyncio.run(_collect_streaming_response(result))
+
         assert isinstance(result, StreamingResponse)
-        assert result.media_type == "application/json"
-        assert "word_trend_speeches_wt-ticket-1.json" in result.headers["content-disposition"]
+        assert result.media_type == "application/zip"
+        assert "word_trend_speeches_wt-ticket-1.zip" in result.headers["content-disposition"]
+        with zipfile.ZipFile(io.BytesIO(body), "r") as archive:
+            assert archive.namelist() == ["word_trend_speeches_wt-ticket-1.json"]
+            payload = json.loads(archive.read("word_trend_speeches_wt-ticket-1.json").decode("utf-8"))
+            assert payload == [
+                {"year": 1970, "name": "A. Svensson", "party_abbrev": "S", "document_name": "prot-1970--1"}
+            ]
 
     def test_download_returns_404_for_missing_ticket(self):
         wt_service = MagicMock()
@@ -799,8 +825,71 @@ class TestWordTrendSpeechesTicketEndpoints:
                     ticket_id="wt-ticket-1",
                     file_format="csv",
                     wt_speeches_ticket_service=wt_service,
+                    download_service=MagicMock(),
                     result_store=MagicMock(),
                 )
             )
 
         assert excinfo.value.status_code == 404
+
+    def test_download_speeches_by_ticket_returns_zip_with_csv_file(self):
+        download_service = DownloadService()
+        result_store = MagicMock()
+        result_store.require_ticket.return_value = type(
+            "Ticket",
+            (),
+            {"status": "ready", "error": None},
+        )()
+        result_store.artifact_path.return_value = MagicMock(exists=MagicMock(return_value=True))
+
+        with patch("pandas.read_feather") as read_feather:
+            read_feather.return_value = pd.DataFrame(
+                [{"year": 1970, "name": "A. Svensson", "party_abbrev": "S", "document_name": "prot-1970--1"}]
+            )
+            result = asyncio.run(
+                download_speeches_by_ticket(
+                    ticket_id="speech-ticket-1",
+                    file_format="csv",
+                    download_service=download_service,
+                    result_store=result_store,
+                )
+            )
+
+        body = asyncio.run(_collect_streaming_response(result))
+
+        assert isinstance(result, StreamingResponse)
+        assert result.media_type == "application/zip"
+        assert "speeches_speech-ticket-1.zip" in result.headers["content-disposition"]
+        with zipfile.ZipFile(io.BytesIO(body), "r") as archive:
+            assert archive.namelist() == ["speeches_speech-ticket-1.csv"]
+
+    def test_download_speeches_by_ticket_returns_zip_with_json_file(self):
+        download_service = DownloadService()
+        result_store = MagicMock()
+        result_store.require_ticket.return_value = type(
+            "Ticket",
+            (),
+            {"status": "ready", "error": None},
+        )()
+        result_store.artifact_path.return_value = MagicMock(exists=MagicMock(return_value=True))
+
+        with patch("pandas.read_feather") as read_feather:
+            read_feather.return_value = pd.DataFrame(
+                [{"year": 1970, "name": "A. Svensson", "party_abbrev": "S", "document_name": "prot-1970--1"}]
+            )
+            result = asyncio.run(
+                download_speeches_by_ticket(
+                    ticket_id="speech-ticket-1",
+                    file_format="json",
+                    download_service=download_service,
+                    result_store=result_store,
+                )
+            )
+
+        body = asyncio.run(_collect_streaming_response(result))
+
+        assert isinstance(result, StreamingResponse)
+        assert result.media_type == "application/zip"
+        assert "speeches_speech-ticket-1.zip" in result.headers["content-disposition"]
+        with zipfile.ZipFile(io.BytesIO(body), "r") as archive:
+            assert archive.namelist() == ["speeches_speech-ticket-1.json"]

--- a/tests/api_swedeb/api/endpoints/test_tool_router.py
+++ b/tests/api_swedeb/api/endpoints/test_tool_router.py
@@ -12,6 +12,7 @@ import pytest
 from fastapi import BackgroundTasks, HTTPException
 from fastapi.responses import JSONResponse, StreamingResponse
 
+from api_swedeb.api.services.download_service import DownloadService
 from api_swedeb.api.services.result_store import ResultStoreNotFound, ResultStorePendingLimitError
 from api_swedeb.api.v1.endpoints.tool_router import (
     download_speeches_by_ticket,
@@ -33,11 +34,9 @@ from api_swedeb.api.v1.endpoints.tool_router import (
     submit_kwic_query,
     submit_word_trend_speeches_query,
 )
-from api_swedeb.api.services.download_service import DownloadService
 from api_swedeb.core.speech import Speech
 from api_swedeb.schemas.kwic_schema import KWICPageResult, KWICQueryRequest, KWICTicketStatus
 from api_swedeb.schemas.ngrams_schema import NGramResult, NGramResultItem
-from api_swedeb.schemas.speeches_schema import SpeechesTicketStatus
 from api_swedeb.schemas.sort_order import SortOrder
 from api_swedeb.schemas.speeches_schema import SpeechesResult, SpeechesResultItem
 from api_swedeb.schemas.word_trends_schema import (

--- a/tests/api_swedeb/api/services/test_download_service.py
+++ b/tests/api_swedeb/api/services/test_download_service.py
@@ -91,6 +91,20 @@ def test_create_stream_from_speech_ids_uses_given_order_and_manifest():
         assert manifest == {"ticket_id": "ticket-1", "speech_count": 2}
 
 
+def test_create_single_file_zip_stream_wraps_content_in_zip_archive():
+    payload = b'{"hello": "world"}'
+
+    stream = DownloadService().create_single_file_zip_stream(
+        archive_filename="speeches_ticket-1.json",
+        content=payload,
+    )
+    zip_bytes = b"".join(stream())
+
+    with zipfile.ZipFile(io.BytesIO(zip_bytes), "r") as archive:
+        assert archive.namelist() == ["speeches_ticket-1.json"]
+        assert archive.read("speeches_ticket-1.json") == payload
+
+
 def test_tar_gz_strategy_streams_plain_text_entries():
     search_service = MagicMock()
     commons = MagicMock()


### PR DESCRIPTION
Streamline ticket-based download endpoints to return ZIP files instead of plain CSV or JSON, ensuring consistency across speech exports. Introduce a helper function for single-file ZIP streaming and update relevant tests. Additionally, implement namespaced prerelease tags for frontend builds to avoid ambiguous git references, mapping `FRONTEND_VERSION=staging|test` to `frontend-staging|frontend-test`. Update documentation to reflect these changes while maintaining compatibility with existing asset names.

Fixes #312

Refs humlab-swedeb/swedeb_frontend#172