### PR TITLE
perf(search): precompute chamber and party person_id maps

### DIFF
--- a/api_swedeb/api/services/corpus_loader.py
+++ b/api_swedeb/api/services/corpus_loader.py
@@ -170,6 +170,38 @@ class CorpusLoader:
         return self.person_codecs.decode(self.person_codecs.persons_of_interest, drop=False)
 
     @cached_property
+    def chamber_person_ids(self) -> dict[str, set[str]]:
+        """Map lowercase chamber_abbrev -> set of person_ids present in that chamber.
+
+        Precomputed from document_index once, then reused on every
+        SearchService filter call. See issue #320.
+        """
+        di = self.document_index
+        abbrev = (
+            di["chamber_abbrev"].str.lower()
+            if pd.api.types.is_string_dtype(di["chamber_abbrev"])
+            else di["chamber_abbrev"]
+        )
+        result: dict[str, set[str]] = {}
+        for abbrev_val, person_id in zip(abbrev, di["person_id"]):
+            result.setdefault(abbrev_val, set()).add(person_id)
+        return result
+
+    @cached_property
+    def party_person_ids(self) -> dict[int, set[str]]:
+        """Map party_id -> set of person_ids in that party.
+
+        Precomputed from person_codecs.person_party once, then reused on
+        every SearchService filter call. Same-pattern companion to
+        chamber_person_ids per issue #320.
+        """
+        pp = self.person_codecs.person_party
+        result: dict[int, set[str]] = {}
+        for party_id, person_id in zip(pp["party_id"], pp["person_id"]):
+            result.setdefault(int(party_id), set()).add(person_id)
+        return result
+
+    @cached_property
     def year_range(self) -> tuple[int, int]:
         """Get corpus min and max year (cached after first access)."""
         try:

--- a/api_swedeb/api/services/search_service.py
+++ b/api_swedeb/api/services/search_service.py
@@ -78,21 +78,14 @@ class SearchService:
 
             if key == "party_id":
                 ivalues: list[int] = [int(v) for v in values]
-                person_party = getattr(self._loader.person_codecs, 'person_party')
-                party_person_ids = (
-                    person_party.loc[person_party.party_id.isin(ivalues), "person_id"].drop_duplicates().tolist()
-                )
-                mask &= df.index.isin(_normalize_like_index(party_person_ids))
+                party_map = self._loader.party_person_ids
+                allowed_person_ids = set().union(*(party_map.get(v, set()) for v in ivalues))
+                mask &= df.index.isin(_normalize_like_index(list(allowed_person_ids)))
             elif key == "chamber_abbrev":
                 svalues: list[str] = [str(v).lower() for v in values]
-                di: pd.DataFrame = self._loader.vectorized_corpus.document_index
-                chamber_abbrev = (
-                    di["chamber_abbrev"].str.lower()
-                    if pd.api.types.is_string_dtype(di["chamber_abbrev"])
-                    else di["chamber_abbrev"]
-                )
-                chamber_person_ids = di.loc[chamber_abbrev.isin(svalues), "person_id"].drop_duplicates().tolist()
-                mask &= df.index.isin(_normalize_like_index(chamber_person_ids))
+                chamber_map = self._loader.chamber_person_ids
+                allowed_person_ids = set().union(*(chamber_map.get(v, set()) for v in svalues))
+                mask &= df.index.isin(_normalize_like_index(list(allowed_person_ids)))
             else:
                 if key in df.columns:
                     mask &= df[key].isin(values)

--- a/tests/api_swedeb/api/services/test_search_service.py
+++ b/tests/api_swedeb/api/services/test_search_service.py
@@ -37,6 +37,8 @@ def mock_loader() -> MagicMock:
             "chamber_abbrev": ["ak", "fk", "ak"],
         }
     )
+    loader.chamber_person_ids = {"ak": {"p1", "p3"}, "fk": {"p2"}}
+    loader.party_person_ids = {1: {"p1", "p3"}, 2: {"p2"}}
 
     loader.document_index = pd.DataFrame({"speech_id": ["i-1", "i-2"]})
     loader.prebuilt_speech_index = pd.DataFrame(
@@ -163,6 +165,7 @@ def test_get_filtered_speakers_handles_mixed_case_chamber_values(service: Search
             "chamber_abbrev": ["Ak", "FK", "aK"],
         }
     )
+    mock_loader.chamber_person_ids = {"ak": {"p1", "p3"}, "fk": {"p2"}}
     speakers = pd.DataFrame(
         {"name": ["Alice", "Bob", "Charlie"]},
         index=pd.Index(["p1", "p2", "p3"], name="person_id"),
@@ -197,6 +200,8 @@ def test_get_filtered_speakers_normalizes_index_value_type(service: SearchServic
             "chamber_abbrev": ["AK", "FK", "AK"],
         }
     )
+    mock_loader.party_person_ids = {1: {"1", "3"}, 2: {"2"}}
+    mock_loader.chamber_person_ids = {"ak": {"1", "3"}, "fk": {"2"}}
     speakers = pd.DataFrame(
         {"name": ["Alice", "Bob", "Charlie"]},
         index=pd.Index([1, 2, 3], name="person_id"),


### PR DESCRIPTION
## Summary

Precompute `chamber_abbrev → person_ids` and `party_id → person_ids` maps once on `CorpusLoader` and use them in `SearchService._get_filtered_speakers` instead of rescanning `vectorized_corpus.document_index` (1M+ rows) and `person_codecs.person_party` on every filter call.

Fixes #320.

## Why this matters

Issue #320 (roger-mahler) points at `SearchService._get_filtered_speakers` at `api_swedeb/api/services/search_service.py:85-94` on `dev`:

```python
di: pd.DataFrame = self._loader.vectorized_corpus.document_index
chamber_abbrev = (
    di["chamber_abbrev"].str.lower()
    if pd.api.types.is_string_dtype(di["chamber_abbrev"])
    else di["chamber_abbrev"]
)
chamber_person_ids = di.loc[chamber_abbrev.isin(svalues), "person_id"].drop_duplicates().tolist()
```

`document_index` is the DTM index (1M+ rows). The mapping `chamber → set(person_id)` is static after corpus load but was being rebuilt on every request. The `party_id` branch five lines above has the same shape (`person_party.loc[...].drop_duplicates().tolist()`), and the issue explicitly notes it as a candidate for the same treatment.

The fix follows the `decoded_persons` pattern already present in `corpus_loader.py:167` (also a `@cached_property` over index data). Lookups become O(1) after first access instead of O(n) on every call.

## Changes

`api_swedeb/api/services/corpus_loader.py` (+32 lines):
- Add `chamber_person_ids -> dict[str, set[str]]` as `@cached_property`, built from `document_index`, lowercasing the chamber abbreviation consistently with the current filter behavior.
- Add `party_person_ids -> dict[int, set[str]]` as `@cached_property`, built from `person_codecs.person_party`, keyed by `int(party_id)` to match the cast in `_get_filtered_speakers`.

`api_swedeb/api/services/search_service.py` (-13, +6):
- `party_id` branch: `set().union(*(party_map.get(v, set()) for v in ivalues))` against `self._loader.party_person_ids`.
- `chamber_abbrev` branch: same pattern against `self._loader.chamber_person_ids`.
- Renamed the local variable to `allowed_person_ids` so it does not shadow the new loader method name.

`tests/api_swedeb/api/services/test_search_service.py` (+5):
- `mock_loader` fixture: add `chamber_person_ids` and `party_person_ids` mock maps consistent with the existing `document_index` / `person_party` mock data.
- `test_get_filtered_speakers_handles_mixed_case_chamber_values`: also override `mock_loader.chamber_person_ids` to match the overridden data so the new code path is exercised.
- `test_get_filtered_speakers_normalizes_index_value_type`: same (overrides `document_index` with int-typed `person_id` values, so the mock maps use string variants matching the fixture's normalized values).

The existing `vectorized_corpus.document_index` and `person_codecs.person_party` mocks are kept in place — other tests still depend on them for non-filter code paths, and keeping them avoids churn.

## Testing

`python -m compileall` on the touched files passes. I was not able to run the full pytest suite locally (the repo's `tests/conftest.py` imports `ccc` from `cwb-ccc` which requires local corpus fixtures). Upstream CI will exercise the full test matrix; the three updated tests target exactly the changed code path.

## Branch target

Targeted at `dev`, matching PR #321 (Roger's merge that landed the current `_get_filtered_speakers` implementation this PR edits).

## AI disclosure

This contribution was developed with AI assistance (Codex).
