### PR TITLE
fix(download): ticketed kwic export endpoints

### DIFF
--- a/api_swedeb/api/services/kwic_ticket_service.py
+++ b/api_swedeb/api/services/kwic_ticket_service.py
@@ -343,6 +343,23 @@ class KWICTicketService:
 
         return (sort_by.value, TICKET_ROW_ID), (sort_order == SortOrder.asc, True)
 
+    def get_full_artifact(self, ticket_id: str, result_store: ResultStore) -> pd.DataFrame:
+        if ConfigValue("development.celery_enabled", default=False).resolve():
+            artifact_path: Path = result_store.artifact_path(ticket_id)
+            if not artifact_path.exists():
+                raise ResultStoreNotFound("Ticket artifact not found or expired")
+            try:
+                data: pd.DataFrame = pd.read_feather(artifact_path)
+            except Exception as exc:
+                raise ResultStoreNotFound("Ticket artifact not found or expired") from exc
+        else:
+            ticket: TicketMeta = result_store.require_ticket(ticket_id)
+            if ticket.status != TicketStatus.READY:
+                raise ResultStoreNotFound("Ticket is not ready")
+            data = result_store.load_artifact(ticket_id)
+
+        return data.drop(columns=[TICKET_ROW_ID], errors="ignore")
+
     def _query_meta(self, request: KWICQueryRequest) -> dict[str, Any]:
         return {
             "search": request.search,

--- a/api_swedeb/api/v1/endpoints/tool_router.py
+++ b/api_swedeb/api/v1/endpoints/tool_router.py
@@ -182,6 +182,57 @@ async def get_kwic_ticket_results(
     return result
 
 
+@router.get("/kwic/download/{ticket_id}")
+async def download_kwic_ticket(
+    ticket_id: str,
+    file_format: str = Query("json", alias="format", description="Download format: csv or json"),
+    kwic_ticket_service: KWICTicketService = Depends(get_kwic_ticket_service),
+    download_service: DownloadService = Depends(get_download_service),
+    result_store: ResultStore = Depends(get_result_store),
+) -> StreamingResponse:
+    try:
+        ticket = result_store.require_ticket(ticket_id)
+    except ResultStoreNotFound as exc:
+        raise HTTPException(status_code=404, detail="Ticket not found or expired") from exc
+
+    if ticket.status == TicketStatus.PENDING:
+        raise HTTPException(status_code=409, detail="Ticket not ready")
+    if ticket.status == TicketStatus.ERROR:
+        raise HTTPException(status_code=409, detail=ticket.error or "Ticket failed")
+
+    try:
+        data = kwic_ticket_service.get_full_artifact(ticket_id, result_store)
+    except Exception as exc:
+        raise HTTPException(status_code=404, detail="Ticket artifact not found or expired") from exc
+
+    inner_filename = f"kwic_{ticket_id}.{file_format}"
+
+    if file_format == "csv":
+        content = data.to_csv(index=False).encode("utf-8")
+    else:
+        content = data.to_json(orient="records", force_ascii=False).encode("utf-8")
+
+    ticket_expires_at = getattr(ticket, "expires_at", None)
+    manifest = download_service.build_download_manifest(
+        ticket_meta={
+            **(getattr(ticket, "manifest_meta", None) or {}),
+            "file_format": file_format,
+            "total_hits": getattr(ticket, "total_hits", None),
+            "expires_at": ticket_expires_at.isoformat() if ticket_expires_at is not None else None,
+        }
+    )
+
+    return StreamingResponse(
+        download_service.create_single_file_zip_stream(
+            archive_filename=inner_filename,
+            content=content,
+            manifest=manifest,
+        )(),
+        media_type="application/zip",
+        headers={"Content-Disposition": f'attachment; filename="kwic_{ticket_id}.zip"'},
+    )
+
+
 @router.get("/kwic/{search}", response_model=KeywordInContextResult)
 async def get_kwic_results(
     commons: CommonParams,
@@ -575,6 +626,38 @@ async def download_speeches_by_ticket(
             content=content,
             manifest=manifest,
         )(),
+        media_type="application/zip",
+        headers={"Content-Disposition": f'attachment; filename="speeches_{ticket_id}.zip"'},
+    )
+
+
+@router.get("/speeches/archive/{ticket_id}")
+async def download_speeches_archive_by_ticket(
+    ticket_id: str,
+    download_service: DownloadService = Depends(get_download_service),
+    result_store: ResultStore = Depends(get_result_store),
+    search_service: SearchService = Depends(get_search_service),
+) -> StreamingResponse:
+    try:
+        ticket = result_store.require_ticket(ticket_id)
+    except ResultStoreNotFound as exc:
+        raise HTTPException(status_code=404, detail="Ticket not found or expired") from exc
+
+    if ticket.status == TicketStatus.PENDING:
+        raise HTTPException(status_code=409, detail="Ticket not ready")
+    if ticket.status == TicketStatus.ERROR:
+        raise HTTPException(status_code=409, detail=ticket.error or "Ticket failed")
+    if ticket.speech_ids is None or ticket.manifest_meta is None:
+        raise HTTPException(status_code=404, detail="Ticket artifact not found or expired")
+
+    streamer = download_service.create_stream_from_speech_ids(
+        search_service=search_service,
+        speech_ids=ticket.speech_ids,
+        manifest_meta=ticket.manifest_meta,
+    )
+
+    return StreamingResponse(
+        streamer(),
         media_type="application/zip",
         headers={"Content-Disposition": f'attachment; filename="speeches_{ticket_id}.zip"'},
     )

--- a/api_swedeb/api/v1/endpoints/tool_router.py
+++ b/api_swedeb/api/v1/endpoints/tool_router.py
@@ -1,3 +1,4 @@
+from enum import StrEnum
 from typing import Annotated, Any, Literal
 
 import fastapi
@@ -78,6 +79,20 @@ CommonParams = Annotated[CommonQueryParams, Depends()]
 
 
 router = fastapi.APIRouter(prefix="/v1/tools", tags=["Tools"], responses={404: {"description": "Not found"}})
+
+
+class DownloadFormat(StrEnum):
+    csv = "csv"
+    json = "json"
+
+    @classmethod
+    def _missing_(cls, value: object) -> "DownloadFormat | None":
+        if isinstance(value, str):
+            normalized = value.lower()
+            for member in cls:
+                if member.value == normalized:
+                    return member
+        return None
 
 
 def _pending_retry_headers() -> dict[str, str]:
@@ -185,7 +200,7 @@ async def get_kwic_ticket_results(
 @router.get("/kwic/download/{ticket_id}")
 async def download_kwic_ticket(
     ticket_id: str,
-    file_format: str = Query("json", alias="format", description="Download format: csv or json"),
+    file_format: DownloadFormat = Query(DownloadFormat.json, alias="format", description="Download format: csv or json"),
     kwic_ticket_service: KWICTicketService = Depends(get_kwic_ticket_service),
     download_service: DownloadService = Depends(get_download_service),
     result_store: ResultStore = Depends(get_result_store),
@@ -202,12 +217,12 @@ async def download_kwic_ticket(
 
     try:
         data = kwic_ticket_service.get_full_artifact(ticket_id, result_store)
-    except Exception as exc:
+    except ResultStoreNotFound as exc:
         raise HTTPException(status_code=404, detail="Ticket artifact not found or expired") from exc
 
-    inner_filename = f"kwic_{ticket_id}.{file_format}"
+    inner_filename = f"kwic_{ticket_id}.{file_format.value}"
 
-    if file_format == "csv":
+    if file_format is DownloadFormat.csv:
         content = data.to_csv(index=False).encode("utf-8")
     else:
         content = data.to_json(orient="records", force_ascii=False).encode("utf-8")
@@ -216,7 +231,7 @@ async def download_kwic_ticket(
     manifest = download_service.build_download_manifest(
         ticket_meta={
             **(getattr(ticket, "manifest_meta", None) or {}),
-            "file_format": file_format,
+            "file_format": file_format.value,
             "total_hits": getattr(ticket, "total_hits", None),
             "expires_at": ticket_expires_at.isoformat() if ticket_expires_at is not None else None,
         }
@@ -393,7 +408,7 @@ async def get_word_trend_speeches_page(
 @router.get("/word_trend_speeches/download/{ticket_id}")
 async def download_word_trend_speeches(
     ticket_id: str,
-    file_format: str = Query("csv", alias="format", description="Download format: csv or json"),
+    file_format: DownloadFormat = Query(DownloadFormat.csv, alias="format", description="Download format: csv or json"),
     wt_speeches_ticket_service: WordTrendSpeechesTicketService = Depends(get_word_trend_speeches_ticket_service),
     download_service: DownloadService = Depends(get_download_service),
     result_store: ResultStore = Depends(get_result_store),
@@ -407,18 +422,18 @@ async def download_word_trend_speeches(
     ticket_meta: dict | None = None
     try:
         ticket_meta = result_store.require_ticket(ticket_id).manifest_meta
-    except Exception:  # noqa: BLE001 ; # pylint: disable=broad-except
+    except ResultStoreNotFound:
         pass
 
-    inner_filename = f"word_trend_speeches_{ticket_id}.{file_format}"
+    inner_filename = f"word_trend_speeches_{ticket_id}.{file_format.value}"
 
-    if file_format == "json":
+    if file_format is DownloadFormat.json:
         content = data.to_json(orient="records", force_ascii=False).encode("utf-8")
     else:
         content = data.to_csv(index=False).encode("utf-8")
 
     manifest = download_service.build_download_manifest(
-        ticket_meta={**(ticket_meta or {}), "file_format": file_format, "row_count": len(data)}
+        ticket_meta={**(ticket_meta or {}), "file_format": file_format.value, "row_count": len(data)}
     )
 
     return StreamingResponse(
@@ -582,7 +597,7 @@ async def get_speeches_page(
 @router.get("/speeches/download/{ticket_id}")
 async def download_speeches_by_ticket(
     ticket_id: str,
-    file_format: str = Query("csv", alias="format", description="Download format: csv or json"),
+    file_format: DownloadFormat = Query(DownloadFormat.csv, alias="format", description="Download format: csv or json"),
     download_service: DownloadService = Depends(get_download_service),
     speeches_ticket_service: SpeechesTicketService = Depends(get_speeches_ticket_service),
     result_store: ResultStore = Depends(get_result_store),
@@ -600,12 +615,12 @@ async def download_speeches_by_ticket(
 
     try:
         data = speeches_ticket_service.get_full_artifact(ticket_id, result_store)
-    except Exception as exc:
+    except ResultStoreNotFound as exc:
         raise HTTPException(status_code=404, detail="Ticket artifact not found or expired") from exc
 
-    inner_filename = f"speeches_{ticket_id}.{file_format}"
+    inner_filename = f"speeches_{ticket_id}.{file_format.value}"
 
-    if file_format == "json":
+    if file_format is DownloadFormat.json:
         content = data.to_json(orient="records", force_ascii=False).encode("utf-8")
     else:
         content = data.to_csv(index=False).encode("utf-8")
@@ -614,7 +629,7 @@ async def download_speeches_by_ticket(
     manifest = download_service.build_download_manifest(
         ticket_meta={
             **(getattr(ticket, "manifest_meta", None) or {}),
-            "file_format": file_format,
+            "file_format": file_format.value,
             "total_hits": getattr(ticket, "total_hits", None),
             "expires_at": ticket_expires_at.isoformat() if ticket_expires_at is not None else None,
         }
@@ -659,7 +674,7 @@ async def download_speeches_archive_by_ticket(
     return StreamingResponse(
         streamer(),
         media_type="application/zip",
-        headers={"Content-Disposition": f'attachment; filename="speeches_{ticket_id}.zip"'},
+        headers={"Content-Disposition": f'attachment; filename="speeches_archive_{ticket_id}.zip"'},
     )
 
 

--- a/tests/api_swedeb/api/endpoints/test_tool_router.py
+++ b/tests/api_swedeb/api/endpoints/test_tool_router.py
@@ -16,6 +16,7 @@ from fastapi.responses import JSONResponse, StreamingResponse
 from api_swedeb.api.services.download_service import DownloadService
 from api_swedeb.api.services.result_store import ResultStoreNotFound, ResultStorePendingLimitError
 from api_swedeb.api.v1.endpoints.tool_router import (
+    DownloadFormat,
     download_kwic_ticket,
     download_speeches_archive_by_ticket,
     download_speeches_by_ticket,
@@ -784,7 +785,7 @@ class TestWordTrendSpeechesTicketEndpoints:
         result = asyncio.run(
             download_word_trend_speeches(
                 ticket_id="wt-ticket-1",
-                file_format="csv",
+                file_format=DownloadFormat.csv,
                 wt_speeches_ticket_service=wt_service,
                 download_service=download_service,
                 result_store=MagicMock(),
@@ -814,7 +815,7 @@ class TestWordTrendSpeechesTicketEndpoints:
         result = asyncio.run(
             download_word_trend_speeches(
                 ticket_id="wt-ticket-1",
-                file_format="json",
+                file_format=DownloadFormat.json,
                 wt_speeches_ticket_service=wt_service,
                 download_service=download_service,
                 result_store=MagicMock(),
@@ -841,7 +842,7 @@ class TestWordTrendSpeechesTicketEndpoints:
             asyncio.run(
                 download_word_trend_speeches(
                     ticket_id="wt-ticket-1",
-                    file_format="csv",
+                    file_format=DownloadFormat.csv,
                     wt_speeches_ticket_service=wt_service,
                     download_service=MagicMock(),
                     result_store=MagicMock(),
@@ -849,6 +850,25 @@ class TestWordTrendSpeechesTicketEndpoints:
             )
 
         assert excinfo.value.status_code == 404
+
+    def test_download_propagates_unexpected_manifest_lookup_errors(self):
+        wt_service = MagicMock()
+        wt_service.get_full_artifact.return_value = pd.DataFrame(
+            [{"year": 1970, "name": "A. Svensson", "party_abbrev": "S", "document_name": "prot-1970--1"}]
+        )
+        result_store = MagicMock()
+        result_store.require_ticket.side_effect = RuntimeError("store unavailable")
+
+        with pytest.raises(RuntimeError, match="store unavailable"):
+            asyncio.run(
+                download_word_trend_speeches(
+                    ticket_id="wt-ticket-1",
+                    file_format=DownloadFormat.csv,
+                    wt_speeches_ticket_service=wt_service,
+                    download_service=MagicMock(),
+                    result_store=result_store,
+                )
+            )
 
     def test_download_kwic_ticket_returns_zip_with_json_file(self):
         download_service = DownloadService()
@@ -866,7 +886,7 @@ class TestWordTrendSpeechesTicketEndpoints:
         result = asyncio.run(
             download_kwic_ticket(
                 ticket_id="kwic-ticket-1",
-                file_format="json",
+                file_format=DownloadFormat.json,
                 kwic_ticket_service=kwic_ticket_service,
                 download_service=download_service,
                 result_store=result_store,
@@ -886,7 +906,7 @@ class TestWordTrendSpeechesTicketEndpoints:
             asyncio.run(
                 download_kwic_ticket(
                     ticket_id="kwic-ticket-1",
-                    file_format="json",
+                    file_format=DownloadFormat.json,
                     kwic_ticket_service=MagicMock(),
                     download_service=MagicMock(),
                     result_store=MagicMock(require_ticket=MagicMock(side_effect=ResultStoreNotFound("missing"))),
@@ -894,6 +914,27 @@ class TestWordTrendSpeechesTicketEndpoints:
             )
 
         assert excinfo.value.status_code == 404
+
+    def test_download_kwic_ticket_propagates_unexpected_artifact_errors(self):
+        result_store = MagicMock()
+        kwic_ticket_service = MagicMock()
+        result_store.require_ticket.return_value = type(
+            "Ticket",
+            (),
+            {"status": "ready", "error": None, "manifest_meta": {}, "total_hits": 1, "expires_at": None},
+        )()
+        kwic_ticket_service.get_full_artifact.side_effect = RuntimeError("corrupt artifact")
+
+        with pytest.raises(RuntimeError, match="corrupt artifact"):
+            asyncio.run(
+                download_kwic_ticket(
+                    ticket_id="kwic-ticket-1",
+                    file_format=DownloadFormat.json,
+                    kwic_ticket_service=kwic_ticket_service,
+                    download_service=MagicMock(),
+                    result_store=result_store,
+                )
+            )
 
     def test_download_speeches_by_ticket_returns_zip_with_csv_file(self):
         download_service = DownloadService()
@@ -911,7 +952,7 @@ class TestWordTrendSpeechesTicketEndpoints:
         result = asyncio.run(
             download_speeches_by_ticket(
                 ticket_id="speech-ticket-1",
-                file_format="csv",
+                file_format=DownloadFormat.csv,
                 download_service=download_service,
                 speeches_ticket_service=speeches_ticket_service,
                 result_store=result_store,
@@ -942,7 +983,7 @@ class TestWordTrendSpeechesTicketEndpoints:
         result = asyncio.run(
             download_speeches_by_ticket(
                 ticket_id="speech-ticket-1",
-                file_format="json",
+                file_format=DownloadFormat.json,
                 download_service=download_service,
                 speeches_ticket_service=speeches_ticket_service,
                 result_store=result_store,
@@ -956,6 +997,27 @@ class TestWordTrendSpeechesTicketEndpoints:
         assert "speeches_speech-ticket-1.zip" in result.headers["content-disposition"]
         with zipfile.ZipFile(io.BytesIO(body), "r") as archive:
             assert archive.namelist() == ["manifest.json", "speeches_speech-ticket-1.json"]
+
+    def test_download_speeches_by_ticket_propagates_unexpected_artifact_errors(self):
+        result_store = MagicMock()
+        speeches_ticket_service = MagicMock()
+        result_store.require_ticket.return_value = type(
+            "Ticket",
+            (),
+            {"status": "ready", "error": None, "manifest_meta": {}, "total_hits": 1, "expires_at": None},
+        )()
+        speeches_ticket_service.get_full_artifact.side_effect = RuntimeError("corrupt artifact")
+
+        with pytest.raises(RuntimeError, match="corrupt artifact"):
+            asyncio.run(
+                download_speeches_by_ticket(
+                    ticket_id="speech-ticket-1",
+                    file_format=DownloadFormat.json,
+                    download_service=MagicMock(),
+                    speeches_ticket_service=speeches_ticket_service,
+                    result_store=result_store,
+                )
+            )
 
     def test_download_speeches_archive_by_ticket_returns_text_zip(self):
         download_service = DownloadService()
@@ -987,7 +1049,7 @@ class TestWordTrendSpeechesTicketEndpoints:
 
         assert isinstance(result, StreamingResponse)
         assert result.media_type == "application/zip"
-        assert "speeches_kwic-ticket-1.zip" in result.headers["content-disposition"]
+        assert "speeches_archive_kwic-ticket-1.zip" in result.headers["content-disposition"]
         with zipfile.ZipFile(io.BytesIO(body), "r") as archive:
             assert archive.namelist() == ["manifest.json", "Alice_Andersson_i-1.txt"]
 

--- a/tests/api_swedeb/api/endpoints/test_tool_router.py
+++ b/tests/api_swedeb/api/endpoints/test_tool_router.py
@@ -16,6 +16,8 @@ from fastapi.responses import JSONResponse, StreamingResponse
 from api_swedeb.api.services.download_service import DownloadService
 from api_swedeb.api.services.result_store import ResultStoreNotFound, ResultStorePendingLimitError
 from api_swedeb.api.v1.endpoints.tool_router import (
+    download_kwic_ticket,
+    download_speeches_archive_by_ticket,
     download_speeches_by_ticket,
     download_word_trend_speeches,
     get_kwic_results,
@@ -848,6 +850,51 @@ class TestWordTrendSpeechesTicketEndpoints:
 
         assert excinfo.value.status_code == 404
 
+    def test_download_kwic_ticket_returns_zip_with_json_file(self):
+        download_service = DownloadService()
+        result_store = MagicMock()
+        kwic_ticket_service = MagicMock()
+        result_store.require_ticket.return_value = type(
+            "Ticket",
+            (),
+            {"status": "ready", "error": None, "manifest_meta": {}, "total_hits": 1, "expires_at": None},
+        )()
+        kwic_ticket_service.get_full_artifact.return_value = pd.DataFrame(
+            [{"left_word": "vi", "node_word": "debatt", "right_word": "nu", "speech_id": "i-1"}]
+        )
+
+        result = asyncio.run(
+            download_kwic_ticket(
+                ticket_id="kwic-ticket-1",
+                file_format="json",
+                kwic_ticket_service=kwic_ticket_service,
+                download_service=download_service,
+                result_store=result_store,
+            )
+        )
+
+        body = asyncio.run(_collect_streaming_response(result))
+
+        assert isinstance(result, StreamingResponse)
+        assert result.media_type == "application/zip"
+        assert "kwic_kwic-ticket-1.zip" in result.headers["content-disposition"]
+        with zipfile.ZipFile(io.BytesIO(body), "r") as archive:
+            assert archive.namelist() == ["manifest.json", "kwic_kwic-ticket-1.json"]
+
+    def test_download_kwic_ticket_returns_404_for_missing_ticket(self):
+        with pytest.raises(HTTPException) as excinfo:
+            asyncio.run(
+                download_kwic_ticket(
+                    ticket_id="kwic-ticket-1",
+                    file_format="json",
+                    kwic_ticket_service=MagicMock(),
+                    download_service=MagicMock(),
+                    result_store=MagicMock(require_ticket=MagicMock(side_effect=ResultStoreNotFound("missing"))),
+                )
+            )
+
+        assert excinfo.value.status_code == 404
+
     def test_download_speeches_by_ticket_returns_zip_with_csv_file(self):
         download_service = DownloadService()
         result_store = MagicMock()
@@ -909,6 +956,53 @@ class TestWordTrendSpeechesTicketEndpoints:
         assert "speeches_speech-ticket-1.zip" in result.headers["content-disposition"]
         with zipfile.ZipFile(io.BytesIO(body), "r") as archive:
             assert archive.namelist() == ["manifest.json", "speeches_speech-ticket-1.json"]
+
+    def test_download_speeches_archive_by_ticket_returns_text_zip(self):
+        download_service = DownloadService()
+        result_store = MagicMock()
+        search_service = MagicMock()
+        result_store.require_ticket.return_value = type(
+            "Ticket",
+            (),
+            {
+                "status": "ready",
+                "error": None,
+                "speech_ids": ["i-1"],
+                "manifest_meta": {"ticket_id": "kwic-ticket-1"},
+            },
+        )()
+        search_service.get_speaker_names.return_value = {"i-1": "Alice Andersson"}
+        search_service.get_speeches_text_batch.return_value = iter([("i-1", "speech text for i-1")])
+
+        result = asyncio.run(
+            download_speeches_archive_by_ticket(
+                ticket_id="kwic-ticket-1",
+                download_service=download_service,
+                result_store=result_store,
+                search_service=search_service,
+            )
+        )
+
+        body = asyncio.run(_collect_streaming_response(result))
+
+        assert isinstance(result, StreamingResponse)
+        assert result.media_type == "application/zip"
+        assert "speeches_kwic-ticket-1.zip" in result.headers["content-disposition"]
+        with zipfile.ZipFile(io.BytesIO(body), "r") as archive:
+            assert archive.namelist() == ["manifest.json", "Alice_Andersson_i-1.txt"]
+
+    def test_download_speeches_archive_by_ticket_returns_404_for_missing_ticket(self):
+        with pytest.raises(HTTPException) as excinfo:
+            asyncio.run(
+                download_speeches_archive_by_ticket(
+                    ticket_id="kwic-ticket-1",
+                    download_service=MagicMock(),
+                    result_store=MagicMock(require_ticket=MagicMock(side_effect=ResultStoreNotFound("missing"))),
+                    search_service=MagicMock(),
+                )
+            )
+
+        assert excinfo.value.status_code == 404
 
 
 class TestSpeechesTicketEndpoints:

--- a/tests/integration/test_kwic_ticket_validation.py
+++ b/tests/integration/test_kwic_ticket_validation.py
@@ -106,7 +106,7 @@ def test_ticket_download_manifest_matches_kwic_baseline(
     ticket_id = kwic_ticket_validation_sample["ticket_id"]
     sync_rows = kwic_ticket_validation_sample["sync_rows"]
 
-    response = ticket_validation_client.post(f"{VERSION}/speeches/download?ticket_id={ticket_id}")
+    response = ticket_validation_client.get(f"{VERSION}/speeches/archive/{ticket_id}")
     assert response.status_code == 200
     assert response.headers["content-type"] == "application/zip"
 
@@ -133,3 +133,27 @@ def test_ticket_download_manifest_matches_kwic_baseline(
     assert manifest["checksum"] == expected_checksum
     assert len(names) == len(speech_ids) + 1
     assert names[0] == "manifest.json"
+
+
+def test_kwic_download_json_matches_ticket_rows(
+    ticket_validation_client: TestClient, kwic_ticket_validation_sample: dict
+):
+    ticket_id = kwic_ticket_validation_sample["ticket_id"]
+    ticket_rows = kwic_ticket_validation_sample["ticket_rows"]
+
+    response = ticket_validation_client.get(
+        f"{VERSION}/kwic/download/{ticket_id}",
+        params={"format": "json"},
+    )
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "application/zip"
+
+    with zipfile.ZipFile(io.BytesIO(response.content), "r") as archive:
+        names = archive.namelist()
+        manifest = json.loads(archive.read("manifest.json").decode("utf-8"))
+        payload = json.loads(archive.read(f"kwic_{ticket_id}.json").decode("utf-8"))
+
+    assert names == ["manifest.json", f"kwic_{ticket_id}.json"]
+    assert manifest["ticket_id"] == ticket_id
+    assert manifest["file_format"] == "json"
+    assert payload == ticket_rows

--- a/tests/integration/test_kwic_ticket_validation.py
+++ b/tests/integration/test_kwic_ticket_validation.py
@@ -109,6 +109,7 @@ def test_ticket_download_manifest_matches_kwic_baseline(
     response = ticket_validation_client.get(f"{VERSION}/speeches/archive/{ticket_id}")
     assert response.status_code == 200
     assert response.headers["content-type"] == "application/zip"
+    assert f"speeches_archive_{ticket_id}.zip" in response.headers["content-disposition"]
 
     with zipfile.ZipFile(io.BytesIO(response.content), "r") as archive:
         manifest = json.loads(archive.read("manifest.json").decode("utf-8"))
@@ -157,3 +158,35 @@ def test_kwic_download_json_matches_ticket_rows(
     assert manifest["ticket_id"] == ticket_id
     assert manifest["file_format"] == "json"
     assert payload == ticket_rows
+
+
+def test_kwic_download_rejects_invalid_format(
+    ticket_validation_client: TestClient, kwic_ticket_validation_sample: dict
+):
+    ticket_id = kwic_ticket_validation_sample["ticket_id"]
+
+    response = ticket_validation_client.get(
+        f"{VERSION}/kwic/download/{ticket_id}",
+        params={"format": "../x"},
+    )
+
+    assert response.status_code == 422
+
+
+def test_kwic_download_normalizes_uppercase_format(
+    ticket_validation_client: TestClient, kwic_ticket_validation_sample: dict
+):
+    ticket_id = kwic_ticket_validation_sample["ticket_id"]
+
+    response = ticket_validation_client.get(
+        f"{VERSION}/kwic/download/{ticket_id}",
+        params={"format": "JSON"},
+    )
+    assert response.status_code == 200
+
+    with zipfile.ZipFile(io.BytesIO(response.content), "r") as archive:
+        names = archive.namelist()
+        manifest = json.loads(archive.read("manifest.json").decode("utf-8"))
+
+    assert names == ["manifest.json", f"kwic_{ticket_id}.json"]
+    assert manifest["file_format"] == "json"

--- a/tests/integration/test_speeches_ticket_validation.py
+++ b/tests/integration/test_speeches_ticket_validation.py
@@ -355,6 +355,18 @@ def test_download_csv_default_format(speeches_ticket_sample: dict, speeches_tick
     assert f"speeches_{ticket_id}.zip" in response.headers["content-disposition"]
 
 
+def test_download_rejects_invalid_format(speeches_ticket_sample: dict, speeches_ticket_client: TestClient):
+    """Test that unsupported download formats are rejected."""
+    ticket_id = speeches_ticket_sample["ticket_id"]
+
+    response = speeches_ticket_client.get(
+        f"{VERSION}/speeches/download/{ticket_id}",
+        params={"format": "xlsx"},
+    )
+
+    assert response.status_code == 422
+
+
 def test_download_returns_404_for_nonexistent_ticket(speeches_ticket_client: TestClient):
     """Test that download returns 404 for nonexistent ticket."""
     response = speeches_ticket_client.get(

--- a/tests/integration/test_wt_speeches_ticket_validation.py
+++ b/tests/integration/test_wt_speeches_ticket_validation.py
@@ -378,6 +378,15 @@ def test_download_json_is_parseable(wt_ticket_client: TestClient, wt_ticket_samp
     assert len(rows) == total_hits
 
 
+def test_download_rejects_invalid_format(wt_ticket_client: TestClient, wt_ticket_sample: dict):
+    ticket_id = wt_ticket_sample["ticket_id"]
+    response = wt_ticket_client.get(
+        f"{VERSION}/word_trend_speeches/download/{ticket_id}",
+        params={"format": "../x"},
+    )
+    assert response.status_code == 422
+
+
 def test_download_returns_404_for_unknown_ticket(wt_ticket_client: TestClient):
     response = wt_ticket_client.get(
         f"{VERSION}/word_trend_speeches/download/nonexistent-ticket-id",


### PR DESCRIPTION
## Summary

Fixes the remaining ticketed download gaps on the backend by adding dedicated ticket-backed export routes for KWIC results and speech archives.

Closes #331

## What changed

- Added a ticket-backed KWIC download endpoint that exports the full stored artifact as zipped JSON or CSV
- Added a dedicated ticket-backed speeches archive endpoint for downloading speech text ZIPs from ticket results
- Added backend coverage for the new endpoints
- Updated KWIC integration validation to use the dedicated ticket archive flow

## Why

The frontend had moved to ticket-based search flows, but the backend still lacked a proper KWIC artifact download route and still relied on the compatibility speeches download interface for some ticket-derived downloads. That kept parts of the download workflow on legacy behavior.
