### PR TITLE
Remove 'public' from riksdagsdebatter.se URL and improve API functionality

### DIFF
--- a/api_swedeb/api/params.py
+++ b/api_swedeb/api/params.py
@@ -21,9 +21,9 @@ def build_filter_opts(
     speech_id: list[str] | None = None,
     include_year: bool = True,
 ) -> dict[str, Any]:
-    year_opts: dict[str, tuple[int, int]] = {}
+    year_opts: dict[str, dict[str, int]] = {}
     if include_year and (from_year or to_year):
-        year_opts = {"year": (from_year or 0, to_year or 3000)}
+        year_opts = {"year": {"low": from_year or 0, "high": to_year or 3000}}
 
     return {
         **({"party_id": party_id} if party_id else {}),

--- a/api_swedeb/api/v1/endpoints/metadata_router.py
+++ b/api_swedeb/api/v1/endpoints/metadata_router.py
@@ -38,13 +38,13 @@ year = r"^\d{4}$"
 @router.get("/start_year", response_model=int)
 async def get_meta_start_year(loader=Depends(get_corpus_loader)):
     """Get the first year in the corpus"""
-    return int(loader.document_index["year"].min())
+    return loader.year_range[0]
 
 
 @router.get("/end_year", response_model=int)
 async def get_meta_end_year(loader=Depends(get_corpus_loader)):
     """Get the last year in the corpus"""
-    return int(loader.document_index["year"].max())
+    return loader.year_range[1]
 
 
 @router.get("/parties", response_model=PartyList)

--- a/api_swedeb/api/v1/endpoints/tool_router.py
+++ b/api_swedeb/api/v1/endpoints/tool_router.py
@@ -200,7 +200,9 @@ async def get_kwic_ticket_results(
 @router.get("/kwic/download/{ticket_id}")
 async def download_kwic_ticket(
     ticket_id: str,
-    file_format: DownloadFormat = Query(DownloadFormat.json, alias="format", description="Download format: csv or json"),
+    file_format: DownloadFormat = Query(
+        DownloadFormat.json, alias="format", description="Download format: csv or json"
+    ),
     kwic_ticket_service: KWICTicketService = Depends(get_kwic_ticket_service),
     download_service: DownloadService = Depends(get_download_service),
     result_store: ResultStore = Depends(get_result_store),

--- a/api_swedeb/app.py
+++ b/api_swedeb/app.py
@@ -5,6 +5,8 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import RedirectResponse
 from fastapi.staticfiles import StaticFiles
+from starlette.exceptions import HTTPException as StarletteHTTPException
+from starlette.types import Scope
 
 from api_swedeb.api.container import AppContainer
 from api_swedeb.api.services.result_store import ResultStore
@@ -13,6 +15,22 @@ from api_swedeb.core.configuration import ConfigValue, get_config_store
 
 # pylint: disable=import-outside-toplevel
 DEFAULT_CONFIG_SOURCE = os.environ.get("SWEDEB_CONFIG_PATH", "config/config.yml")
+
+
+class SPAStaticFiles(StaticFiles):
+    """StaticFiles that serves index.html for any path not matched by an actual file.
+
+    Required for Vue Router history-mode: direct navigation to /tools/wordtrends
+    must return the SPA shell instead of 404.
+    """
+
+    async def get_response(self, path: str, scope: Scope):  # type: ignore[override]
+        try:
+            return await super().get_response(path, scope)
+        except StarletteHTTPException as exc:
+            if exc.status_code == 404:
+                return await super().get_response("index.html", scope)
+            raise
 
 
 def create_app(*, config_source: str | None = DEFAULT_CONFIG_SOURCE, static_dir: str | None = None) -> FastAPI:
@@ -71,7 +89,8 @@ def create_app(*, config_source: str | None = DEFAULT_CONFIG_SOURCE, static_dir:
 
     if static_dir is not None:
         # Mounted last so API routes take precedence.
-        # html=True enables SPA fallback: unknown paths return index.html (required for history-mode routing).
-        app.mount("/", StaticFiles(directory=static_dir, html=True), name="static")
+        # SPAStaticFiles falls back to index.html for any path not matched by an actual file,
+        # which is required for Vue Router history-mode (direct navigation / hard refresh).
+        app.mount("/", SPAStaticFiles(directory=static_dir, html=True), name="static")
 
     return app

--- a/api_swedeb/core/common/utility/pandas_utils.py
+++ b/api_swedeb/core/common/utility/pandas_utils.py
@@ -94,6 +94,8 @@ def _create_mask(df: pd.DataFrame, name: str, value: Any, sign: bool = True) -> 
         ),
     ):
         m = df[name].isin(value)
+    elif isinstance(value, dict) and "low" in value and "high" in value:
+        m = df[name].between(value["low"], value["high"])
     elif isinstance(value, tuple):
         m = df[name].between(*value)
     elif isinstance(value, (bool, Number, str)):
@@ -144,6 +146,8 @@ def create_mask(doc: pd.DataFrame, args: dict) -> np.ndarray:
                                 (fx, v)                 fx(df.k, attr_value)
                                      v: list            df.k.isin(lst)
                                      v: set             df.k.isin(set)
+                        {"low": x, "high": y}           df.k.between(x, y)
+                                    (x, y)              df.k.between(x, y)
                                      v                  df.k == v
 
     """
@@ -189,7 +193,11 @@ def create_mask(doc: pd.DataFrame, args: dict) -> np.ndarray:
             else (
                 attr_operator(value_serie, attr_value)  # type: ignore
                 if attr_operator is not None
-                else value_serie.isin(attr_value) if isinstance(attr_value, (list, set)) else value_serie == attr_value
+                else value_serie.isin(attr_value)
+                if isinstance(attr_value, (list, set))
+                else value_serie.between(attr_value["low"], attr_value["high"])
+                if isinstance(attr_value, dict) and "low" in attr_value
+                else value_serie == attr_value
             )
         )
 

--- a/tests/api_swedeb/core/common/utility/test_pandas_utils.py
+++ b/tests/api_swedeb/core/common/utility/test_pandas_utils.py
@@ -69,6 +69,47 @@ def test_create_mask_supports_operator_range_negation_and_skips_unknown_columns(
     assert mask.tolist() == [False, False, True]
 
 
+def test_create_mask_dict_range_matches_between():
+    """Dict {"low": x, "high": y} must behave like between(x, y), not isin([x, y])."""
+    doc = pd.DataFrame({"year": [1867, 1900, 2000, 2022]})
+
+    mask = pu.create_mask(doc, {"year": {"low": 1900, "high": 2000}})
+
+    assert mask.tolist() == [False, True, True, False]
+
+
+def test_create_mask_dict_range_includes_boundaries():
+    """Boundaries must be inclusive (between is inclusive by default)."""
+    doc = pd.DataFrame({"year": [1867, 1900, 2022]})
+
+    mask = pu.create_mask(doc, {"year": {"low": 1867, "high": 2022}})
+
+    assert mask.tolist() == [True, True, True]
+
+
+def test_create_mask_dict_range_vs_list_isin_are_distinct():
+    """A plain list must still use isin, not between — confirming the two semantics are separate."""
+    doc = pd.DataFrame({"year": [1867, 1900, 2022]})
+
+    range_mask = pu.create_mask(doc, {"year": {"low": 1867, "high": 2022}})
+    isin_mask = pu.create_mask(doc, {"year": [1867, 2022]})
+
+    # range matches all three; isin matches only the boundary years
+    assert range_mask.tolist() == [True, True, True]
+    assert isin_mask.tolist() == [True, False, True]
+
+
+def test_private_create_mask_dict_range():
+    """_create_mask also handles the dict range correctly."""
+    doc = pd.DataFrame({"year": [1867, 1950, 2022]})
+
+    m = pu._create_mask(doc, "year", {"low": 1900, "high": 2000})
+    assert m.tolist() == [False, True, False]
+
+    m_neg = pu._create_mask(doc, "year", {"low": 1900, "high": 2000}, sign=False)
+    assert m_neg.tolist() == [True, False, True]
+
+
 def test_create_mask_raises_for_invalid_tuple_and_unknown_operator():
     doc = pd.DataFrame({"year": [2020], "count": [1]})
 


### PR DESCRIPTION
Fix failed auto-redirects to riksdagsdebatter.se URL  by implementing a custom static file handler to serve the index.html for unknown paths, enabling Vue Router history-mode. 

Fixes humlab-swedeb/swedeb-api#196