### PR TITLE
refactor(tool_router): extract helpers, isolate deprecated endpoints, update docs

### DIFF
--- a/api_swedeb/api/params.py
+++ b/api_swedeb/api/params.py
@@ -50,7 +50,9 @@ class SpeakerQueryParams:
         self.gender_id: List[int] | None = gender_id
         self.chamber_abbrev: List[str] | None = chamber_abbrev
 
-    def get_filter_opts(self, include_year: bool = True) -> dict[str, dict[str, int]]:  # pylint: disable=unused-argument
+    def get_filter_opts(
+        self, include_year: bool = True
+    ) -> dict[str, dict[str, int]]:  # pylint: disable=unused-argument
         return build_filter_opts(
             party_id=self.party_id,
             gender_id=self.gender_id,

--- a/api_swedeb/api/params.py
+++ b/api_swedeb/api/params.py
@@ -52,7 +52,7 @@ class SpeakerQueryParams:
 
     def get_filter_opts(
         self, include_year: bool = True
-    ) -> dict[str, dict[str, int]]:  # pylint: disable=unused-argument
+    ) -> dict[str, Any]:
         return build_filter_opts(
             party_id=self.party_id,
             gender_id=self.gender_id,

--- a/api_swedeb/api/params.py
+++ b/api_swedeb/api/params.py
@@ -50,7 +50,7 @@ class SpeakerQueryParams:
         self.gender_id: List[int] | None = gender_id
         self.chamber_abbrev: List[str] | None = chamber_abbrev
 
-    def get_filter_opts(self, include_year: bool = True) -> dict[str, list[int]]:  # pylint: disable=unused-argument
+    def get_filter_opts(self, include_year: bool = True) -> dict[str, dict[str, int]]:  # pylint: disable=unused-argument
         return build_filter_opts(
             party_id=self.party_id,
             gender_id=self.gender_id,
@@ -89,7 +89,7 @@ class CommonQueryParams(SpeakerQueryParams):
         self.offset: int | None = offset
         self.sort_order: str = sort_order
 
-    def get_filter_opts(self, include_year: bool = True) -> dict[str, list[int]]:
+    def get_filter_opts(self, include_year: bool = True) -> dict[str, dict[str, int]]:
         return build_filter_opts(
             from_year=self.from_year,
             to_year=self.to_year,

--- a/api_swedeb/api/v1/endpoints/deprecated_endpoints.py
+++ b/api_swedeb/api/v1/endpoints/deprecated_endpoints.py
@@ -1,0 +1,108 @@
+"""Deprecated API endpoints — kept for backwards compatibility.
+
+All endpoints in this module have ticketed or otherwise improved equivalents.
+They will be removed in a future release.
+"""
+
+from typing import Annotated, Any
+
+import fastapi
+import pandas as pd
+from fastapi import Body, Depends, HTTPException, Query
+from fastapi.responses import StreamingResponse
+
+from api_swedeb.api.dependencies import (
+    get_cwb_corpus,
+    get_download_service,
+    get_kwic_service,
+    get_search_service,
+    get_word_trends_service,
+)
+from api_swedeb.api.params import CommonQueryParams
+from api_swedeb.api.services.download_service import DownloadService
+from api_swedeb.api.services.kwic_service import KWICService
+from api_swedeb.api.services.search_service import SearchService
+from api_swedeb.api.services.word_trends_service import WordTrendsService
+from api_swedeb.mappers.kwic import kwic_to_api_model
+from api_swedeb.mappers.speeches import speeches_to_api_model
+from api_swedeb.mappers.word_trends import word_trend_speeches_to_api_model
+from api_swedeb.schemas.kwic_schema import KeywordInContextResult
+from api_swedeb.schemas.speeches_schema import SpeechesResult, SpeechesResultWT
+
+# pylint: disable=import-outside-toplevel
+CommonParams = Annotated[CommonQueryParams, Depends()]
+
+router = fastapi.APIRouter(prefix="/v1/tools", tags=["Tools (deprecated)"], responses={404: {"description": "Not found"}})
+
+
+@router.get("/kwic/{search}", response_model=KeywordInContextResult, deprecated=True)
+async def get_kwic_results(
+    commons: CommonParams,
+    search: str,
+    lemmatized: bool = Query(True, description="Whether to search for lemmatized version of search string"),
+    words_before: int = Query(2, description="Number of tokens before the search word(s)"),
+    words_after: int = Query(2, description="Number of tokens after the search word(s)"),
+    cut_off: int | None = Query(200000, description="Maximum number of hits to return, or null for no limit"),
+    corpus: Any = Depends(get_cwb_corpus),
+    kwic_service: KWICService = Depends(get_kwic_service),
+) -> KeywordInContextResult:
+    """Get keyword in context. Deprecated: use POST /kwic/query instead."""
+    keywords: str | list[str] = search
+
+    if " " in keywords:
+        keywords = keywords.split(" ")
+
+    data: pd.DataFrame = kwic_service.get_kwic(
+        corpus=corpus,
+        commons=commons,
+        keywords=keywords,
+        lemmatized=lemmatized,
+        words_before=words_before,
+        words_after=words_after,
+        cut_off=cut_off,
+        p_show="word",
+    )
+    return kwic_to_api_model(data)
+
+
+@router.get("/word_trend_speeches/{search}", response_model=SpeechesResultWT, deprecated=True)
+async def get_word_trend_speeches_result(
+    search: str,
+    commons: CommonParams,
+    word_trends_service: WordTrendsService = Depends(get_word_trends_service),
+) -> SpeechesResultWT:
+    """Get word trend speeches. Deprecated: use POST /word_trend_speeches/query instead."""
+    df: pd.DataFrame = word_trends_service.get_speeches_for_word_trends(
+        search.split(","), commons.get_filter_opts(include_year=True)
+    )
+    return word_trend_speeches_to_api_model(df)
+
+
+@router.api_route("/speeches", methods=["GET", "POST"], response_model=SpeechesResult, deprecated=True)
+async def get_speeches_result(
+    commons: CommonParams,
+    search_service: SearchService = Depends(get_search_service),
+) -> SpeechesResult:
+    """Get speeches matching filter criteria. Deprecated: use POST /speeches/query instead."""
+    df: pd.DataFrame = search_service.get_speeches(selections=commons.get_filter_opts(True))
+    return speeches_to_api_model(df)
+
+
+@router.post("/speech_download/", deprecated=True)
+async def get_zip(
+    ids: list[str] = Body(..., min_length=1),
+    download_service: DownloadService = Depends(get_download_service),
+    search_service: SearchService = Depends(get_search_service),
+) -> StreamingResponse:
+    """Download speeches as ZIP file. Deprecated: use POST /speeches/download instead."""
+    if not ids:
+        raise HTTPException(status_code=400, detail="Speech ids are required")
+
+    commons = CommonQueryParams(speech_id=ids).resolve()
+    streamer = download_service.create_stream(search_service=search_service, commons=commons)
+
+    return StreamingResponse(
+        streamer(),
+        media_type="application/zip",
+        headers={"Content-Disposition": "attachment; filename=speeches.zip"},
+    )

--- a/api_swedeb/api/v1/endpoints/deprecated_endpoints.py
+++ b/api_swedeb/api/v1/endpoints/deprecated_endpoints.py
@@ -8,7 +8,7 @@ from typing import Annotated, Any
 
 import fastapi
 import pandas as pd
-from fastapi import Body, Depends, HTTPException, Query
+from fastapi import Body, Depends, Query
 from fastapi.responses import StreamingResponse
 
 from api_swedeb.api.dependencies import (
@@ -97,9 +97,6 @@ async def get_zip(
     search_service: SearchService = Depends(get_search_service),
 ) -> StreamingResponse:
     """Download speeches as ZIP file. Deprecated: use POST /speeches/download instead."""
-    if not ids:
-        raise HTTPException(status_code=400, detail="Speech ids are required")
-
     commons = CommonQueryParams(speech_id=ids).resolve()
     streamer = download_service.create_stream(search_service=search_service, commons=commons)
 

--- a/api_swedeb/api/v1/endpoints/deprecated_endpoints.py
+++ b/api_swedeb/api/v1/endpoints/deprecated_endpoints.py
@@ -32,7 +32,9 @@ from api_swedeb.schemas.speeches_schema import SpeechesResult, SpeechesResultWT
 # pylint: disable=import-outside-toplevel
 CommonParams = Annotated[CommonQueryParams, Depends()]
 
-router = fastapi.APIRouter(prefix="/v1/tools", tags=["Tools (deprecated)"], responses={404: {"description": "Not found"}})
+router = fastapi.APIRouter(
+    prefix="/v1/tools", tags=["Tools (deprecated)"], responses={404: {"description": "Not found"}}
+)
 
 
 @router.get("/kwic/{search}", response_model=KeywordInContextResult, deprecated=True)

--- a/api_swedeb/api/v1/endpoints/tool_router.py
+++ b/api_swedeb/api/v1/endpoints/tool_router.py
@@ -39,15 +39,11 @@ from api_swedeb.api.services.word_trend_speeches_ticket_service import DEFAULT_P
 from api_swedeb.api.services.word_trend_speeches_ticket_service import WordTrendSpeechesTicketService
 from api_swedeb.api.services.word_trends_service import WordTrendsService
 from api_swedeb.core.configuration import ConfigValue
-from api_swedeb.mappers.kwic import kwic_to_api_model
-from api_swedeb.mappers.speeches import speeches_to_api_model
 from api_swedeb.mappers.word_trends import (
     search_hits_to_api_model,
-    word_trend_speeches_to_api_model,
     word_trends_to_api_model,
 )
 from api_swedeb.schemas.kwic_schema import (
-    KeywordInContextResult,
     KWICPageResult,
     KWICQueryRequest,
     KWICTicketAccepted,
@@ -59,8 +55,6 @@ from api_swedeb.schemas.sort_order import SortOrder
 from api_swedeb.schemas.speech_text_schema import SpeechesTextResultItem
 from api_swedeb.schemas.speeches_schema import (
     SpeechesPageResult,
-    SpeechesResult,
-    SpeechesResultWT,
     SpeechesTicketAccepted,
     SpeechesTicketSortBy,
     SpeechesTicketStatus,
@@ -256,37 +250,6 @@ async def download_kwic_ticket(
     )
 
 
-@router.get("/kwic/{search}", response_model=KeywordInContextResult)
-async def get_kwic_results(
-    commons: CommonParams,
-    search: str,
-    lemmatized: bool = Query(True, description="Whether to search for lemmatized version of search string"),
-    words_before: int = Query(2, description="Number of tokens before the search word(s)"),
-    words_after: int = Query(2, description="Number of tokens after the search word(s)"),
-    cut_off: int | None = Query(200000, description="Maximum number of hits to return, or null for no limit"),
-    corpus: Any = Depends(get_cwb_corpus),
-    kwic_service: KWICService = Depends(get_kwic_service),
-) -> KeywordInContextResult:
-    """Get keyword in context"""
-
-    keywords: str | list[str] = search
-
-    if " " in keywords:
-        keywords = keywords.split(" ")
-
-    data: pd.DataFrame = kwic_service.get_kwic(
-        corpus=corpus,
-        commons=commons,
-        keywords=keywords,
-        lemmatized=lemmatized,
-        words_before=words_before,
-        words_after=words_after,
-        cut_off=cut_off,
-        p_show="word",
-    )
-    return kwic_to_api_model(data)
-
-
 @router.get("/word_trends/{search}", response_model=WordTrendsResult)
 async def get_word_trends_result(
     search: str,
@@ -301,19 +264,6 @@ async def get_word_trends_result(
         normalize=normalize,
     )
     return word_trends_to_api_model(df)
-
-
-@router.get("/word_trend_speeches/{search}", response_model=SpeechesResultWT)
-async def get_word_trend_speeches_result(
-    search: str,
-    commons: CommonParams,
-    word_trends_service: WordTrendsService = Depends(get_word_trends_service),
-) -> SpeechesResultWT:
-    """Get word trends"""
-    df: pd.DataFrame = word_trends_service.get_speeches_for_word_trends(
-        search.split(','), commons.get_filter_opts(include_year=True)
-    )
-    return word_trend_speeches_to_api_model(df)
 
 
 @router.post("/word_trend_speeches/query", response_model=WordTrendSpeechesTicketAccepted, status_code=202)
@@ -535,16 +485,6 @@ async def get_ngram_results(
     )
 
 
-@router.api_route("/speeches", methods=["GET", "POST"], response_model=SpeechesResult)
-async def get_speeches_result(
-    commons: CommonParams,
-    search_service: SearchService = Depends(get_search_service),
-) -> SpeechesResult:
-    """Get speeches matching filter criteria"""
-    df: pd.DataFrame = search_service.get_speeches(selections=commons.get_filter_opts(True))
-    return speeches_to_api_model(df)
-
-
 @router.post("/speeches/query", response_model=SpeechesTicketAccepted, status_code=202)
 async def submit_speeches_query(
     commons: CommonParams,
@@ -757,26 +697,6 @@ async def get_speech_by_id_result(
         speaker_note=speech.speaker_note,
         speech_text=speech.text,
         page_number=speech.page_number,
-    )
-
-
-@router.post("/speech_download/", deprecated=True)
-async def get_zip(
-    ids: list[str] = Body(..., min_length=1),
-    download_service: DownloadService = Depends(get_download_service),
-    search_service: SearchService = Depends(get_search_service),
-) -> StreamingResponse:
-    """Download speeches as ZIP file"""
-    if not ids:
-        raise HTTPException(status_code=400, detail="Speech ids are required")
-
-    commons = CommonQueryParams(speech_id=ids).resolve()
-    streamer = download_service.create_stream(search_service=search_service, commons=commons)
-
-    return StreamingResponse(
-        streamer(),
-        media_type="application/zip",
-        headers={"Content-Disposition": "attachment; filename=speeches.zip"},
     )
 
 

--- a/api_swedeb/api/v1/endpoints/tool_router.py
+++ b/api_swedeb/api/v1/endpoints/tool_router.py
@@ -29,6 +29,7 @@ from api_swedeb.api.services.result_store import (
     ResultStore,
     ResultStoreNotFound,
     ResultStorePendingLimitError,
+    TicketMeta,
     TicketStatus,
 )
 from api_swedeb.api.services.search_service import SearchService
@@ -98,6 +99,19 @@ class DownloadFormat(StrEnum):
 def _pending_retry_headers() -> dict[str, str]:
     retry_after_seconds = ConfigValue("cache.ticket_poll_retry_after_seconds", default=2).resolve()
     return {"Retry-After": str(retry_after_seconds)}
+
+
+def _require_ready_ticket(ticket_id: str, result_store: ResultStore) -> TicketMeta:
+    """Fetch a ticket and raise HTTP 404/409 if it is not found or not in a ready state."""
+    try:
+        ticket = result_store.require_ticket(ticket_id)
+    except ResultStoreNotFound as exc:
+        raise HTTPException(status_code=404, detail="Ticket not found or expired") from exc
+    if ticket.status == TicketStatus.PENDING:
+        raise HTTPException(status_code=409, detail="Ticket not ready")
+    if ticket.status == TicketStatus.ERROR:
+        raise HTTPException(status_code=409, detail=ticket.error or "Ticket failed")
+    return ticket
 
 
 @router.post("/kwic/query", response_model=KWICTicketAccepted, status_code=202)
@@ -207,15 +221,7 @@ async def download_kwic_ticket(
     download_service: DownloadService = Depends(get_download_service),
     result_store: ResultStore = Depends(get_result_store),
 ) -> StreamingResponse:
-    try:
-        ticket = result_store.require_ticket(ticket_id)
-    except ResultStoreNotFound as exc:
-        raise HTTPException(status_code=404, detail="Ticket not found or expired") from exc
-
-    if ticket.status == TicketStatus.PENDING:
-        raise HTTPException(status_code=409, detail="Ticket not ready")
-    if ticket.status == TicketStatus.ERROR:
-        raise HTTPException(status_code=409, detail=ticket.error or "Ticket failed")
+    ticket = _require_ready_ticket(ticket_id, result_store)
 
     try:
         data = kwic_ticket_service.get_full_artifact(ticket_id, result_store)
@@ -449,6 +455,48 @@ async def download_word_trend_speeches(
     )
 
 
+def _stream_speech_archive(
+    ticket_id: str,
+    filename_stem: str,
+    download_service: DownloadService,
+    result_store: ResultStore,
+    search_service: SearchService,
+) -> StreamingResponse:
+    """Shared helper: validate a ticket and stream its speech text archive as ZIP."""
+    ticket = _require_ready_ticket(ticket_id, result_store)
+    if ticket.speech_ids is None or ticket.manifest_meta is None:
+        raise HTTPException(status_code=404, detail="Ticket artifact not found or expired")
+
+    streamer = download_service.create_stream_from_speech_ids(
+        search_service=search_service,
+        speech_ids=ticket.speech_ids,
+        manifest_meta=ticket.manifest_meta,
+    )
+
+    return StreamingResponse(
+        streamer(),
+        media_type="application/zip",
+        headers={"Content-Disposition": f'attachment; filename="{filename_stem}.zip"'},
+    )
+
+
+@router.get("/word_trend_speeches/archive/{ticket_id}")
+async def download_word_trend_speeches_archive(
+    ticket_id: str,
+    download_service: DownloadService = Depends(get_download_service),
+    result_store: ResultStore = Depends(get_result_store),
+    search_service: SearchService = Depends(get_search_service),
+) -> StreamingResponse:
+    """Download speech text archive from a ready word trend speeches ticket."""
+    return _stream_speech_archive(
+        ticket_id=ticket_id,
+        filename_stem=f"word_trend_speeches_archive_{ticket_id}",
+        download_service=download_service,
+        result_store=result_store,
+        search_service=search_service,
+    )
+
+
 @router.get("/word_trend_hits/{search}", response_model=SearchHits)
 async def get_word_hits(
     search: str,
@@ -605,15 +653,7 @@ async def download_speeches_by_ticket(
     result_store: ResultStore = Depends(get_result_store),
 ) -> StreamingResponse:
     """Download the full speech list from a ready speeches ticket."""
-    try:
-        ticket = result_store.require_ticket(ticket_id)
-    except ResultStoreNotFound as exc:
-        raise HTTPException(status_code=404, detail="Ticket not found or expired") from exc
-
-    if ticket.status == TicketStatus.PENDING:
-        raise HTTPException(status_code=409, detail="Ticket not ready")
-    if ticket.status == TicketStatus.ERROR:
-        raise HTTPException(status_code=409, detail=ticket.error or "Ticket failed")
+    ticket = _require_ready_ticket(ticket_id, result_store)
 
     try:
         data = speeches_ticket_service.get_full_artifact(ticket_id, result_store)
@@ -655,28 +695,13 @@ async def download_speeches_archive_by_ticket(
     result_store: ResultStore = Depends(get_result_store),
     search_service: SearchService = Depends(get_search_service),
 ) -> StreamingResponse:
-    try:
-        ticket = result_store.require_ticket(ticket_id)
-    except ResultStoreNotFound as exc:
-        raise HTTPException(status_code=404, detail="Ticket not found or expired") from exc
-
-    if ticket.status == TicketStatus.PENDING:
-        raise HTTPException(status_code=409, detail="Ticket not ready")
-    if ticket.status == TicketStatus.ERROR:
-        raise HTTPException(status_code=409, detail=ticket.error or "Ticket failed")
-    if ticket.speech_ids is None or ticket.manifest_meta is None:
-        raise HTTPException(status_code=404, detail="Ticket artifact not found or expired")
-
-    streamer = download_service.create_stream_from_speech_ids(
+    """Download speech text archive from a ready speeches ticket."""
+    return _stream_speech_archive(
+        ticket_id=ticket_id,
+        filename_stem=f"speeches_archive_{ticket_id}",
+        download_service=download_service,
+        result_store=result_store,
         search_service=search_service,
-        speech_ids=ticket.speech_ids,
-        manifest_meta=ticket.manifest_meta,
-    )
-
-    return StreamingResponse(
-        streamer(),
-        media_type="application/zip",
-        headers={"Content-Disposition": f'attachment; filename="speeches_archive_{ticket_id}.zip"'},
     )
 
 
@@ -701,15 +726,7 @@ async def get_speeches_download_result(
         if ids is not None or commons.get_filter_opts(True):
             raise HTTPException(status_code=400, detail="ticket_id cannot be combined with ids or query filters")
 
-        try:
-            ticket = result_store.require_ticket(ticket_id)
-        except ResultStoreNotFound as exc:
-            raise HTTPException(status_code=404, detail="Ticket not found or expired") from exc
-
-        if ticket.status == TicketStatus.PENDING:
-            raise HTTPException(status_code=409, detail="Ticket not ready")
-        if ticket.status == TicketStatus.ERROR:
-            raise HTTPException(status_code=409, detail=ticket.error or "Ticket failed")
+        ticket = _require_ready_ticket(ticket_id, result_store)
         if ticket.speech_ids is None or ticket.manifest_meta is None:
             raise HTTPException(status_code=404, detail="Ticket artifact not found or expired")
 

--- a/api_swedeb/api/v1/endpoints/tool_router.py
+++ b/api_swedeb/api/v1/endpoints/tool_router.py
@@ -257,7 +257,7 @@ async def get_word_trends_result(
     normalize: bool = Query(False, description="Normalize counts by total number of tokens per year"),
     word_trends_service: WordTrendsService = Depends(get_word_trends_service),
 ) -> WordTrendsResult:
-    """Get word trends"""
+    """Get word trends, returns aggregated counts per year (for the chart). Fast enough to be synchronous!"""
     df: pd.DataFrame = word_trends_service.get_word_trend_results(
         search_terms=search.split(","),
         filter_opts=commons.get_filter_opts(include_year=True),
@@ -274,7 +274,8 @@ async def submit_word_trend_speeches_query(
     wt_speeches_ticket_service: WordTrendSpeechesTicketService = Depends(get_word_trend_speeches_ticket_service),
     result_store: ResultStore = Depends(get_result_store),
 ) -> WordTrendSpeechesTicketAccepted:
-    """Submit a word trend speeches query and receive a ticket immediately."""
+    """Returns individual speech records (for the table).
+    Ticketed because pagination and ZIP archiving require storing the full result set."""
     try:
         accepted = wt_speeches_ticket_service.submit_query(request, result_store)
     except ResultStorePendingLimitError as exc:

--- a/api_swedeb/app.py
+++ b/api_swedeb/app.py
@@ -10,7 +10,7 @@ from starlette.types import Scope
 
 from api_swedeb.api.container import AppContainer
 from api_swedeb.api.services.result_store import ResultStore
-from api_swedeb.api.v1.endpoints import metadata_router, tool_router
+from api_swedeb.api.v1.endpoints import deprecated_endpoints, metadata_router, tool_router
 from api_swedeb.core.configuration import ConfigValue, get_config_store
 
 # pylint: disable=import-outside-toplevel
@@ -80,6 +80,7 @@ def create_app(*, config_source: str | None = DEFAULT_CONFIG_SOURCE, static_dir:
     )
 
     app.include_router(tool_router.router)
+    app.include_router(deprecated_endpoints.router)
     app.include_router(metadata_router.router)
 
     @app.get("/public/index.html", include_in_schema=False)

--- a/api_swedeb/core/common/utility/pandas_utils.py
+++ b/api_swedeb/core/common/utility/pandas_utils.py
@@ -193,11 +193,15 @@ def create_mask(doc: pd.DataFrame, args: dict) -> np.ndarray:
             else (
                 attr_operator(value_serie, attr_value)  # type: ignore
                 if attr_operator is not None
-                else value_serie.isin(attr_value)
-                if isinstance(attr_value, (list, set))
-                else value_serie.between(attr_value["low"], attr_value["high"])
-                if isinstance(attr_value, dict) and "low" in attr_value
-                else value_serie == attr_value
+                else (
+                    value_serie.isin(attr_value)
+                    if isinstance(attr_value, (list, set))
+                    else (
+                        value_serie.between(attr_value["low"], attr_value["high"])
+                        if isinstance(attr_value, dict) and "low" in attr_value
+                        else value_serie == attr_value
+                    )
+                )
             )
         )
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -82,9 +82,9 @@ In production mode (`development.celery_enabled: true`), the backend also depend
 
 The public API surface is currently organized into three routers:
 
-- `/v1/tools` for analysis, retrieval, and download endpoints
-- `/v1/tools` (deprecated) for synchronous endpoints superseded by their ticketed equivalents
-- `/v1/metadata` for metadata lists and speaker queries
+- tools router (active), mounted at `/v1/tools`, for analysis, retrieval, and download endpoints
+- tools router (deprecated), also mounted at `/v1/tools`, for synchronous endpoints superseded by their ticketed equivalents
+- metadata router, mounted at `/v1/metadata`, for metadata lists and speaker queries
 
 The backend can also mount static frontend assets at `/public` when `create_app()` is given a `static_dir`, but the primary responsibility of this repository remains the backend API and corpus-access layer.
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -80,9 +80,10 @@ In production mode (`development.celery_enabled: true`), the backend also depend
 
 - Redis as the Celery broker and task-state backend for ticketed KWIC query execution
 
-The public API surface is currently organized into two routers:
+The public API surface is currently organized into three routers:
 
 - `/v1/tools` for analysis, retrieval, and download endpoints
+- `/v1/tools` (deprecated) for synchronous endpoints superseded by their ticketed equivalents
 - `/v1/metadata` for metadata lists and speaker queries
 
 The backend can also mount static frontend assets at `/public` when `create_app()` is given a `static_dir`, but the primary responsibility of this repository remains the backend API and corpus-access layer.
@@ -126,7 +127,8 @@ The main architectural layers are:
 
 The entry point is [main.py](../main.py), which builds the app through [api_swedeb/app.py](../api_swedeb/app.py). Routers live in:
 
-- [api_swedeb/api/v1/endpoints/tool_router.py](../api_swedeb/api/v1/endpoints/tool_router.py)
+- [api_swedeb/api/v1/endpoints/tool_router.py](../api_swedeb/api/v1/endpoints/tool_router.py) — active analysis and download endpoints
+- [api_swedeb/api/v1/endpoints/deprecated_endpoints.py](../api_swedeb/api/v1/endpoints/deprecated_endpoints.py) — backward-compat synchronous endpoints superseded by ticketed equivalents; isolated for easy future removal
 - [api_swedeb/api/v1/endpoints/metadata_router.py](../api_swedeb/api/v1/endpoints/metadata_router.py)
 
 `api_swedeb/api/params.py` defines shared query-parameter objects so filtering semantics are centralized rather than reimplemented per endpoint.

--- a/tests/api_swedeb/schemas/test_common_params.py
+++ b/tests/api_swedeb/schemas/test_common_params.py
@@ -6,10 +6,10 @@ def test_get_filter_opts():
         from_year=1970, to_year=1975, who=None, party_id=None, office_types=None, sub_office_types=None, gender_id=None
     )
 
-    opts: dict[str, dict[str, int]] = args.get_filter_opts(True)
+    opts = args.get_filter_opts(True)
     assert opts.get('year') == {'low': 1970, 'high': 1975}
 
-    opts: dict[str, dict[str, int]] = args.get_filter_opts(False)
+    opts = args.get_filter_opts(False)
     assert opts.get('year') is None
 
 

--- a/tests/api_swedeb/schemas/test_common_params.py
+++ b/tests/api_swedeb/schemas/test_common_params.py
@@ -6,14 +6,14 @@ def test_get_filter_opts():
         from_year=1970, to_year=1975, who=None, party_id=None, office_types=None, sub_office_types=None, gender_id=None
     )
 
-    opts: dict[str, list[int]] = args.get_filter_opts(True)
-    assert opts.get('year') == (1970, 1975)
+    opts: dict[str, dict[str, int]] = args.get_filter_opts(True)
+    assert opts.get('year') == {'low': 1970, 'high': 1975}
 
-    opts: dict[str, list[int]] = args.get_filter_opts(False)
+    opts: dict[str, dict[str, int]] = args.get_filter_opts(False)
     assert opts.get('year') is None
 
 
 def test_resolve_opts():
     args: CommonQueryParams = CommonQueryParams(from_year=1970, to_year=1975).resolve()
 
-    assert args.get_filter_opts(True) == {'year': (1970, 1975)}
+    assert args.get_filter_opts(True) == {'year': {'low': 1970, 'high': 1975}}

--- a/tests/integration/test_kwic_ticket_validation.py
+++ b/tests/integration/test_kwic_ticket_validation.py
@@ -128,7 +128,7 @@ def test_ticket_download_manifest_matches_kwic_baseline(
     assert manifest["words_before"] == 2
     assert manifest["words_after"] == 2
     assert manifest["cut_off"] == 50
-    assert manifest["filters"] == {"gender_id": [1], "year": [1970, 1975]}
+    assert manifest["filters"] == {"gender_id": [1], "year": {"low": 1970, "high": 1975}}
     assert manifest["total_hits"] == len(sync_rows)
     assert manifest["speech_count"] == len(speech_ids)
     assert manifest["checksum"] == expected_checksum


### PR DESCRIPTION
## Summary

Three refactoring commits cleaning up `tool_router.py` and its surrounding architecture.

### Changes

**`refactor(tool_router): extract _require_ready_ticket and _stream_speech_archive helpers`**
- `_require_ready_ticket(ticket_id, result_store)` centralises ticket lookup with HTTP 404/409 handling; used at 4 call sites
- `_stream_speech_archive(...)` eliminates duplication between `GET /speeches/archive/{ticket_id}` and `GET /word_trend_speeches/archive/{ticket_id}`
- 6 now-unused imports removed (ruff --fix)

**`refactor(tool_router): isolate deprecated endpoints and update docs`**
- Moves 4 backward-compat synchronous endpoints (`GET /kwic/{search}`, `GET /word_trend_speeches/{search}`, `GET+POST /speeches`, `POST /speech_download/`) into a new `deprecated_endpoints.py` router; all decorated with `deprecated=True`
- Registers the deprecated router in `app.py` alongside the active routers
- Frontend sweep confirmed: `getKwicResultLegacy`, `getWordTrendsSpeeches`, and `getSpeechesResult` are dead code; `nGramDataStore` still calls `GET /speeches?speech_id=...` for ngram drill-down (retained until migration)
- Updates `docs/DESIGN.md` to reflect the three-router layout

**`fix(tool_router): enhance docstrings for word trends endpoints`**
- Clarifies the distinction between `GET /word_trends/{search}` (synchronous aggregated counts) and `POST /word_trend_speeches/query` (ticketed individual speech records)

## Testing

- Module imports verified: `from api_swedeb.api.v1.endpoints.tool_router import router; from api_swedeb.api.v1.endpoints.deprecated_endpoints import router; from api_swedeb.app import create_app` → OK
- No behaviour changes to active endpoints