### PR TITLE
Add ticket-based bulk archive generation

### DIFF
--- a/api_swedeb/api/container.py
+++ b/api_swedeb/api/container.py
@@ -38,6 +38,7 @@ from typing import cast
 
 from fastapi import Request
 
+from api_swedeb.api.services.archive_ticket_service import ArchiveTicketService
 from api_swedeb.api.services.corpus_loader import CorpusLoader
 from api_swedeb.api.services.download_service import DownloadService
 from api_swedeb.api.services.kwic_service import KWICService
@@ -64,6 +65,7 @@ class AppContainer:
     kwic_ticket_service: KWICTicketService
     word_trend_speeches_ticket_service: WordTrendSpeechesTicketService
     download_service: DownloadService
+    archive_ticket_service: ArchiveTicketService
 
     @classmethod
     def build(cls) -> AppContainer:
@@ -80,6 +82,7 @@ class AppContainer:
             kwic_ticket_service=KWICTicketService(),
             word_trend_speeches_ticket_service=WordTrendSpeechesTicketService(),
             download_service=DownloadService(),
+            archive_ticket_service=ArchiveTicketService(),
         )
 
 

--- a/api_swedeb/api/dependencies.py
+++ b/api_swedeb/api/dependencies.py
@@ -6,6 +6,7 @@ from fastapi import Depends, Request
 from loguru import logger
 
 from api_swedeb.api.container import AppContainer, get_container
+from api_swedeb.api.services.archive_ticket_service import ArchiveTicketService
 from api_swedeb.api.services.corpus_loader import CorpusLoader
 from api_swedeb.api.services.download_service import DownloadService
 from api_swedeb.api.services.kwic_service import KWICService
@@ -63,6 +64,11 @@ def get_word_trend_speeches_ticket_service(
 def get_download_service(container: AppContainer = Depends(get_container)) -> DownloadService:
     """Get the app-scoped DownloadService instance."""
     return container.download_service
+
+
+def get_archive_ticket_service(container: AppContainer = Depends(get_container)) -> ArchiveTicketService:
+    """Get the app-scoped ArchiveTicketService instance."""
+    return container.archive_ticket_service
 
 
 def get_cwb_corpus_opts() -> dict[str, str | None]:

--- a/api_swedeb/api/services/archive_ticket_service.py
+++ b/api_swedeb/api/services/archive_ticket_service.py
@@ -1,0 +1,195 @@
+"""Archive ticket service — prepare, track, and execute bulk archive generation."""
+
+from __future__ import annotations
+
+import os
+from datetime import UTC, datetime
+from functools import lru_cache
+from pathlib import Path
+from typing import Any
+
+from loguru import logger
+
+from api_swedeb.api.services.result_store import (
+    ResultStore,
+    ResultStoreCapacityError,
+    ResultStoreNotFound,
+    TicketMeta,
+    TicketStatus,
+)
+from api_swedeb.api.services.search_service import SearchService
+from api_swedeb.api.services.ticketed_download_service import TicketedDownloadService
+from api_swedeb.core.configuration import ConfigValue
+from api_swedeb.schemas.bulk_archive_schema import (
+    ArchivePrepareResponse,
+    ArchiveTicketStatus,
+    BulkArchiveFormat,
+)
+
+# ---------------------------------------------------------------------------
+# Per-worker singleton helpers (Celery workers only)
+# ---------------------------------------------------------------------------
+
+
+@lru_cache(maxsize=1)
+def _get_worker_search_service() -> SearchService:
+    from api_swedeb.api.services.corpus_loader import CorpusLoader  # pylint: disable=import-outside-toplevel
+
+    return SearchService(CorpusLoader())
+
+
+@lru_cache(maxsize=1)
+def _get_worker_result_store() -> ResultStore:
+    store = ResultStore.from_config()
+    store.startup_sync()
+    return store
+
+
+# ---------------------------------------------------------------------------
+# Celery task (module-level so Celery can discover it)
+# ---------------------------------------------------------------------------
+
+
+def execute_archive_task(archive_ticket_id: str) -> dict:
+    """Execute an archive generation task in a Celery worker process.
+
+    Registered as a Celery task by the celery_tasks module at import time.
+    """
+    search_service: SearchService = _get_worker_search_service()
+    result_store: ResultStore = _get_worker_result_store()
+    result_store.adopt_ticket(archive_ticket_id)
+
+    _service = ArchiveTicketService()
+    _service.execute_archive_task(
+        archive_ticket_id=archive_ticket_id,
+        result_store=result_store,
+        search_service=search_service,
+    )
+    ticket: TicketMeta = result_store.require_ticket(archive_ticket_id)
+    if ticket.status == TicketStatus.ERROR:
+        raise RuntimeError(ticket.error or f"Archive ticket {archive_ticket_id} failed")
+    if ticket.status != TicketStatus.READY:
+        raise RuntimeError(f"Archive ticket {archive_ticket_id} did not reach ready state")
+
+    return {"archive_ticket_id": archive_ticket_id, "artifact_bytes": ticket.artifact_bytes}
+
+
+class ArchiveTicketService:
+    def prepare(
+        self,
+        *,
+        source_ticket_id: str,
+        archive_format: BulkArchiveFormat,
+        result_store: ResultStore,
+    ) -> ArchivePrepareResponse:
+        """Validate the source ticket and create an archive ticket.
+
+        Raises ResultStoreNotFound if the source ticket is missing.
+        Raises ValueError if the source ticket is not ready.
+        """
+        source_ticket: TicketMeta = result_store.require_ticket(source_ticket_id)
+        if source_ticket.status == TicketStatus.PENDING:
+            raise ValueError("Source ticket is not ready yet")
+        if source_ticket.status == TicketStatus.ERROR:
+            raise ValueError("Source ticket is in an error state")
+        if source_ticket.speech_ids is None:
+            raise ValueError("Source ticket has no speech IDs")
+
+        query_meta: dict[str, Any] = {
+            "source_ticket_id": source_ticket_id,
+            "archive_format": archive_format.value,
+            "speech_count": len(source_ticket.speech_ids),
+            "source_query": source_ticket.query_meta,
+        }
+        archive_ticket: TicketMeta = result_store.create_ticket(
+            query_meta=query_meta,
+            source_ticket_id=source_ticket_id,
+            archive_format=archive_format.value,
+        )
+
+        retry_after: int = ConfigValue("cache.ticket_poll_retry_after_seconds", default=2).resolve()
+        return ArchivePrepareResponse(
+            archive_ticket_id=archive_ticket.ticket_id,
+            status="pending",
+            source_ticket_id=source_ticket_id,
+            archive_format=archive_format.value,
+            retry_after=retry_after,
+        )
+
+    def execute_archive_task(
+        self,
+        *,
+        archive_ticket_id: str,
+        result_store: ResultStore,
+        search_service: SearchService,
+    ) -> None:
+        """Generate the archive artifact and mark the ticket ready or failed."""
+        logger.info(f"Starting execute_archive_task for archive ticket {archive_ticket_id}")
+        try:
+            archive_ticket: TicketMeta = result_store.require_ticket(archive_ticket_id)
+            source_ticket_id: str | None = archive_ticket.source_ticket_id
+            archive_format_str: str | None = archive_ticket.archive_format
+
+            if source_ticket_id is None:
+                raise ValueError("Archive ticket has no source_ticket_id")
+            if archive_format_str is None:
+                raise ValueError("Archive ticket has no archive_format")
+
+            archive_format = BulkArchiveFormat(archive_format_str)
+            source_ticket: TicketMeta = result_store.require_ticket(source_ticket_id)
+            if source_ticket.speech_ids is None:
+                raise ValueError("Source ticket has no speech IDs")
+
+            speech_ids: list[str] = source_ticket.speech_ids
+            dest_path: Path = result_store.archive_artifact_path(archive_ticket_id, archive_format_str)
+            manifest_meta: dict = self._build_manifest(archive_ticket, source_ticket)
+
+            TicketedDownloadService.for_format(archive_format).write(
+                speech_ids=speech_ids,
+                search_service=search_service,
+                dest_path=dest_path,
+                manifest_meta=manifest_meta,
+            )
+
+            result_store.store_archive_ready(
+                archive_ticket_id,
+                artifact_path=dest_path,
+                manifest_meta=manifest_meta,
+                total_hits=len(speech_ids),
+            )
+            logger.info(f"Archive ticket {archive_ticket_id} ready ({len(speech_ids)} speeches)")
+        except ResultStoreCapacityError:
+            logger.warning(f"Result store capacity error for archive ticket {archive_ticket_id}")
+            return
+        except ResultStoreNotFound:
+            logger.warning(f"Result store not found for archive ticket {archive_ticket_id}")
+            return
+        except Exception as exc:  # pylint: disable=broad-except
+            logger.exception(f"Error executing archive ticket {archive_ticket_id}: {exc}")
+            result_store.store_error(archive_ticket_id, message="Failed to generate archive")
+
+    def get_status(self, archive_ticket_id: str, result_store: ResultStore) -> ArchiveTicketStatus:
+        ticket: TicketMeta = result_store.require_ticket(archive_ticket_id)
+        return self._status_model(ticket)
+
+    def _status_model(self, ticket: TicketMeta) -> ArchiveTicketStatus:
+        return ArchiveTicketStatus(
+            archive_ticket_id=ticket.ticket_id,
+            status=ticket.status.value,
+            source_ticket_id=ticket.source_ticket_id,
+            archive_format=ticket.archive_format,
+            speech_count=ticket.total_hits,
+            expires_at=ticket.expires_at,
+            error=ticket.error,
+        )
+
+    def _build_manifest(self, archive_ticket: TicketMeta, source_ticket: TicketMeta) -> dict:
+        return {
+            "archive_ticket_id": archive_ticket.ticket_id,
+            "source_ticket_id": archive_ticket.source_ticket_id,
+            "archive_format": archive_ticket.archive_format,
+            "speech_count": len(source_ticket.speech_ids or []),
+            "generated_at": datetime.now(UTC).isoformat(),
+            "corpus_version": os.environ.get("CORPUS_VERSION", "unknown"),
+            "source_query": source_ticket.query_meta,
+        }

--- a/api_swedeb/api/services/archive_ticket_service.py
+++ b/api_swedeb/api/services/archive_ticket_service.py
@@ -125,8 +125,20 @@ class ArchiveTicketService:
     ) -> None:
         """Generate the archive artifact and mark the ticket ready or failed."""
         logger.info(f"Starting execute_archive_task for archive ticket {archive_ticket_id}")
+
+        # Load the archive ticket first. If it is missing there is nothing to update, so return silently.
         try:
             archive_ticket: TicketMeta = result_store.require_ticket(archive_ticket_id)
+        except ResultStoreNotFound:
+            logger.warning(f"Archive ticket {archive_ticket_id} not found; nothing to update")
+            return
+        except ResultStoreCapacityError:
+            logger.warning(f"Result store capacity error loading archive ticket {archive_ticket_id}")
+            return
+
+        # From here the archive ticket exists. Any NotFound means a dependency (e.g. source ticket)
+        # has expired and the archive ticket must be moved to ERROR so clients stop polling.
+        try:
             source_ticket_id: str | None = archive_ticket.source_ticket_id
             archive_format_str: str | None = archive_ticket.archive_format
 
@@ -161,9 +173,9 @@ class ArchiveTicketService:
         except ResultStoreCapacityError:
             logger.warning(f"Result store capacity error for archive ticket {archive_ticket_id}")
             return
-        except ResultStoreNotFound:
-            logger.warning(f"Result store not found for archive ticket {archive_ticket_id}")
-            return
+        except ResultStoreNotFound as exc:
+            logger.warning(f"Required resource not found for archive ticket {archive_ticket_id}: {exc}")
+            result_store.store_error(archive_ticket_id, message=f"Required resource not found: {exc}")
         except Exception as exc:  # pylint: disable=broad-except
             logger.exception(f"Error executing archive ticket {archive_ticket_id}: {exc}")
             result_store.store_error(archive_ticket_id, message="Failed to generate archive")

--- a/api_swedeb/api/services/result_store.py
+++ b/api_swedeb/api/services/result_store.py
@@ -38,6 +38,8 @@ class TicketMeta:
     manifest_meta: dict | None = None
     error: str | None = None
     ready_at: datetime | None = None
+    source_ticket_id: str | None = None
+    archive_format: str | None = None
 
 
 class ResultStoreError(RuntimeError):
@@ -114,6 +116,7 @@ class ResultStore:
     async def startup(self) -> None:
         with self._lock:
             self.root_dir.mkdir(parents=True, exist_ok=True)
+            (self.root_dir / "archives").mkdir(exist_ok=True)
             self._cleanup_partial_files_locked()
             self._artifact_cache.clear()
             self._sorted_positions_cache.clear()
@@ -135,6 +138,7 @@ class ResultStore:
         """
         with self._lock:
             self.root_dir.mkdir(parents=True, exist_ok=True)
+            (self.root_dir / "archives").mkdir(exist_ok=True)
             self._cleanup_partial_files_locked()
             self._artifact_cache.clear()
             self._sorted_positions_cache.clear()
@@ -174,7 +178,13 @@ class ResultStore:
         with self._lock:
             return self._pending_jobs_locked()
 
-    def create_ticket(self, *, query_meta: dict | None = None) -> TicketMeta:
+    def create_ticket(
+        self,
+        *,
+        query_meta: dict | None = None,
+        source_ticket_id: str | None = None,
+        archive_format: str | None = None,
+    ) -> TicketMeta:
         self.cleanup_expired()
         with self._lock, self._state_lock():
             self._ensure_started_locked()
@@ -188,6 +198,8 @@ class ResultStore:
                 created_at=now,
                 expires_at=self._clamped_expiry(now, now + timedelta(seconds=self.result_ttl_seconds)),
                 query_meta=dict(query_meta or {}),
+                source_ticket_id=source_ticket_id,
+                archive_format=archive_format,
             )
             self._set_ticket_locked(ticket)
             return ticket
@@ -464,6 +476,67 @@ class ResultStore:
     def _partial_path(self, ticket_id: str) -> Path:
         return self.root_dir / f"{ticket_id}{self.ARTIFACT_SUFFIX}{self.PARTIAL_SUFFIX}"
 
+    def archive_artifact_path(self, ticket_id: str, archive_format: str) -> Path:
+        """Return the filesystem path for an archive artifact."""
+        from api_swedeb.schemas.bulk_archive_schema import (  # pylint: disable=import-outside-toplevel
+            ARCHIVE_SUFFIXES,
+            BulkArchiveFormat,
+        )
+
+        suffix = ARCHIVE_SUFFIXES.get(BulkArchiveFormat(archive_format), f".{archive_format}")
+        return self.root_dir / "archives" / f"{ticket_id}{suffix}"
+
+    def store_archive_ready(
+        self,
+        archive_ticket_id: str,
+        *,
+        artifact_path: Path,
+        manifest_meta: dict | None = None,
+        total_hits: int | None = None,
+    ) -> TicketMeta:
+        """Record a completed archive artifact.
+
+        The caller must have already written the file to *artifact_path* atomically.
+        This method updates the archive ticket to READY and accounts for capacity.
+        """
+        if not artifact_path.exists():
+            raise ResultStoreNotFound("Archive artifact file not found")
+
+        artifact_bytes = artifact_path.stat().st_size
+
+        with self._lock, self._state_lock():
+            self._ensure_started_locked()
+            ticket = self._get_ticket_locked(archive_ticket_id)
+            if ticket is None:
+                artifact_path.unlink(missing_ok=True)
+                raise ResultStoreNotFound("Archive ticket not found or expired")
+
+            self._evict_ready_tickets_locked(required_bytes=artifact_bytes, exclude_ticket_id=archive_ticket_id)
+
+            total_capacity = self._artifact_bytes_locked() + artifact_bytes - (ticket.artifact_bytes or 0)
+            if artifact_bytes > self.max_artifact_bytes or total_capacity > self.max_artifact_bytes:
+                artifact_path.unlink(missing_ok=True)
+                message = "Insufficient result-store capacity for archive artifact"
+                self._set_ticket_locked(replace(ticket, status=TicketStatus.ERROR, error=message))
+                raise ResultStoreCapacityError(message)
+
+            ready_at = datetime.now(UTC)
+            updated = replace(
+                ticket,
+                status=TicketStatus.READY,
+                expires_at=self._clamped_expiry(
+                    ticket.created_at, ready_at + timedelta(seconds=self.result_ttl_seconds)
+                ),
+                artifact_path=artifact_path,
+                artifact_bytes=artifact_bytes,
+                total_hits=total_hits if total_hits is not None else ticket.total_hits,
+                manifest_meta=dict(manifest_meta) if manifest_meta is not None else ticket.manifest_meta,
+                error=None,
+                ready_at=ready_at,
+            )
+            self._set_ticket_locked(updated)
+            return replace(updated)
+
     def _cleanup_partial_files_locked(self) -> None:
         if not self.root_dir.exists():
             return
@@ -471,6 +544,12 @@ class ResultStore:
         for suffix in self.PARTIAL_SUFFIXES:
             for path in self.root_dir.glob(f"*{suffix}"):
                 path.unlink(missing_ok=True)
+
+        archives_dir = self.root_dir / "archives"
+        if archives_dir.exists():
+            for suffix in self.PARTIAL_SUFFIXES:
+                for path in archives_dir.glob(f"*{suffix}"):
+                    path.unlink(missing_ok=True)
 
     def _delete_ticket_locked(self, ticket_id: str) -> None:
         ticket = self._get_ticket_locked(ticket_id)
@@ -611,4 +690,6 @@ class ResultStore:
             manifest_meta=dict(payload["manifest_meta"]) if payload.get("manifest_meta") is not None else None,
             error=payload.get("error"),
             ready_at=datetime.fromisoformat(payload["ready_at"]) if payload.get("ready_at") else None,
+            source_ticket_id=payload.get("source_ticket_id"),
+            archive_format=payload.get("archive_format"),
         )

--- a/api_swedeb/api/services/ticketed_download_service.py
+++ b/api_swedeb/api/services/ticketed_download_service.py
@@ -198,7 +198,8 @@ class TicketedDownloadService:
 
         # 3. Use it
         svc = TicketedDownloadService.for_format(BulkArchiveFormat.parquet)
-        svc.write(speech_ids=ids, search_service=svc, dest_path=path)
+        search_service = SearchService(...)
+        svc.write(speech_ids=ids, search_service=search_service, dest_path=path)
     """
 
     def __init__(self, writer: ArchiveWriter, compresslevel: int = 1) -> None:

--- a/api_swedeb/api/services/ticketed_download_service.py
+++ b/api_swedeb/api/services/ticketed_download_service.py
@@ -1,0 +1,238 @@
+"""Ticketed download service — strategy-based bulk archive writing.
+
+Each :class:`ArchiveWriter` implementation handles a single output format.
+Add a new format by:
+
+1. Subclassing :class:`ArchiveWriter` and implementing :meth:`~ArchiveWriter.write`.
+2. Registering the class in :data:`_WRITER_REGISTRY`.
+"""
+
+from __future__ import annotations
+
+import csv
+import gzip
+import json
+import re
+import zipfile
+from abc import ABC, abstractmethod
+from pathlib import Path
+
+from api_swedeb.api.services.search_service import SearchService
+from api_swedeb.core.configuration.inject import ConfigValue
+from api_swedeb.schemas.bulk_archive_schema import BulkArchiveFormat
+
+_UNSAFE_CHARS = re.compile(r"[^\w\-.]")
+
+
+def _safe_filename_part(value: str) -> str:
+    return _UNSAFE_CHARS.sub("_", value).strip("_") or "unknown"
+
+
+# ---------------------------------------------------------------------------
+# Strategy interface
+# ---------------------------------------------------------------------------
+
+
+class ArchiveWriter(ABC):
+    """Strategy interface for writing a bulk speech archive to a file atomically.
+
+    Implementations must write output to ``dest_path`` + ``.partial`` and
+    rename it to *dest_path* on success, or remove the partial file on failure.
+    """
+
+    @abstractmethod
+    def write(
+        self,
+        speech_ids: list[str],
+        search_service: SearchService,
+        dest_path: Path,
+        manifest_meta: dict | None = None,
+        compresslevel: int = 1,
+    ) -> int:
+        """Write archive atomically to *dest_path*.
+
+        Returns the number of bytes written.
+        """
+        raise NotImplementedError
+
+
+# ---------------------------------------------------------------------------
+# Concrete strategies
+# ---------------------------------------------------------------------------
+
+
+class JsonlGzArchiveWriter(ArchiveWriter):
+    """Write speeches as a gzip-compressed JSONL file.
+
+    Each line is a JSON object with ``speech_id`` and ``text`` keys.
+    """
+
+    def write(
+        self,
+        speech_ids: list[str],
+        search_service: SearchService,
+        dest_path: Path,
+        manifest_meta: dict | None = None,  # noqa: ARG002 (not included in JSONL format)
+        compresslevel: int = 1,
+    ) -> int:
+        partial = Path(str(dest_path) + ".partial")
+        partial.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            with gzip.open(str(partial), "wb", compresslevel=compresslevel) as gz:
+                for speech_id, text in search_service.get_speeches_text_batch(speech_ids):
+                    record: dict = {"speech_id": speech_id, "text": text}
+                    line = (json.dumps(record, ensure_ascii=False) + "\n").encode("utf-8")
+                    gz.write(line)
+            partial.replace(dest_path)
+            return dest_path.stat().st_size
+        except Exception:
+            partial.unlink(missing_ok=True)
+            raise
+
+
+class ZipArchiveWriter(ArchiveWriter):
+    """Write speeches as a ZIP file, one ``.txt`` entry per speech.
+
+    A ``manifest.json`` entry is prepended when *manifest_meta* is provided.
+    """
+
+    def write(
+        self,
+        speech_ids: list[str],
+        search_service: SearchService,
+        dest_path: Path,
+        manifest_meta: dict | None = None,
+        compresslevel: int = 1,
+    ) -> int:
+        unknown: str = ConfigValue("display.labels.speaker.unknown", default="unknown").resolve()
+        speaker_names: dict[str, str] = search_service.get_speaker_names(speech_ids)
+        partial = Path(str(dest_path) + ".partial")
+        partial.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            with zipfile.ZipFile(
+                str(partial),
+                mode="w",
+                compression=zipfile.ZIP_DEFLATED,
+                compresslevel=compresslevel,
+                allowZip64=True,
+            ) as zf:
+                if manifest_meta is not None:
+                    zf.writestr("manifest.json", json.dumps(manifest_meta, indent=2, ensure_ascii=False))
+                for speech_id, text in search_service.get_speeches_text_batch(speech_ids):
+                    speaker = speaker_names.get(speech_id, unknown)
+                    filename = f"{_safe_filename_part(speaker)}_{speech_id}.txt"
+                    zf.writestr(filename, text.encode("utf-8"))
+            partial.replace(dest_path)
+            return dest_path.stat().st_size
+        except Exception:
+            partial.unlink(missing_ok=True)
+            raise
+
+
+class CsvArchiveWriter(ArchiveWriter):
+    """Write speeches as a gzip-compressed CSV file.
+
+    Columns: ``speech_id``, ``speaker_name``, ``text``.  Fields are quoted
+    only when necessary (commas, newlines, or embedded quotes).
+    """
+
+    def write(
+        self,
+        speech_ids: list[str],
+        search_service: SearchService,
+        dest_path: Path,
+        manifest_meta: dict | None = None,  # noqa: ARG002 (not included in CSV format)
+        compresslevel: int = 1,
+    ) -> int:
+        unknown: str = ConfigValue("display.labels.speaker.unknown", default="unknown").resolve()
+        speaker_names: dict[str, str] = search_service.get_speaker_names(speech_ids)
+        partial = Path(str(dest_path) + ".partial")
+        partial.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            with gzip.open(partial, "wt", encoding="utf-8", newline="", compresslevel=compresslevel) as gz:
+                writer = csv.writer(gz, quoting=csv.QUOTE_MINIMAL)
+                writer.writerow(["speech_id", "speaker_name", "text"])
+                for speech_id, text in search_service.get_speeches_text_batch(speech_ids):
+                    speaker_name = speaker_names.get(speech_id, unknown)
+                    writer.writerow([speech_id, speaker_name, text])
+            partial.replace(dest_path)
+            return dest_path.stat().st_size
+        except Exception:
+            partial.unlink(missing_ok=True)
+            raise
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+#: Maps each :class:`~api_swedeb.schemas.bulk_archive_schema.BulkArchiveFormat`
+#: to the :class:`ArchiveWriter` class that handles it.  Add an entry here to
+#: register a new output format.
+_WRITER_REGISTRY: dict[BulkArchiveFormat, type[ArchiveWriter]] = {
+    BulkArchiveFormat.jsonl_gz: JsonlGzArchiveWriter,
+    BulkArchiveFormat.zip: ZipArchiveWriter,
+    BulkArchiveFormat.csv_gz: CsvArchiveWriter,
+}
+
+
+# ---------------------------------------------------------------------------
+# Service
+# ---------------------------------------------------------------------------
+
+
+class TicketedDownloadService:
+    """Orchestrates bulk archive writing using an injected :class:`ArchiveWriter` strategy.
+
+    Prefer constructing via :meth:`for_format` rather than directly.
+
+    Example — adding a new format::
+
+        # 1. Implement the strategy
+        class ParquetArchiveWriter(ArchiveWriter):
+            def write(self, speech_ids, search_service, dest_path, manifest_meta=None, compresslevel=1) -> int:
+                ...
+
+        # 2. Register it
+        _WRITER_REGISTRY[BulkArchiveFormat.parquet] = ParquetArchiveWriter
+
+        # 3. Use it
+        svc = TicketedDownloadService.for_format(BulkArchiveFormat.parquet)
+        svc.write(speech_ids=ids, search_service=svc, dest_path=path)
+    """
+
+    def __init__(self, writer: ArchiveWriter, compresslevel: int = 1) -> None:
+        self._writer = writer
+        self.compresslevel = compresslevel
+
+    @classmethod
+    def for_format(cls, archive_format: BulkArchiveFormat, compresslevel: int = 1) -> "TicketedDownloadService":
+        """Return a :class:`TicketedDownloadService` configured for *archive_format*.
+
+        Raises :exc:`ValueError` for unregistered formats.
+        """
+        writer_cls = _WRITER_REGISTRY.get(archive_format)
+        if writer_cls is None:
+            registered = [f.value for f in _WRITER_REGISTRY]
+            raise ValueError(f"Unsupported archive format: {archive_format!r}. Registered formats: {registered}")
+        return cls(writer=writer_cls(), compresslevel=compresslevel)
+
+    def write(
+        self,
+        *,
+        speech_ids: list[str],
+        search_service: SearchService,
+        dest_path: Path,
+        manifest_meta: dict | None = None,
+    ) -> int:
+        """Write the archive to *dest_path* atomically.
+
+        Returns the number of bytes written.
+        """
+        return self._writer.write(
+            speech_ids=speech_ids,
+            search_service=search_service,
+            dest_path=dest_path,
+            manifest_meta=manifest_meta,
+            compresslevel=self.compresslevel,
+        )

--- a/api_swedeb/api/v1/endpoints/tool_router.py
+++ b/api_swedeb/api/v1/endpoints/tool_router.py
@@ -496,7 +496,7 @@ async def prepare_word_trend_speeches_bulk_archive(
     except ValueError as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from exc
 
-    celery_enabled: bool = ConfigValue("development.celery_enabled", default=False).resolve()
+    celery_enabled: bool = bool(ConfigValue("development.celery_enabled", default=False).resolve())
     if celery_enabled:
         import importlib  # pylint: disable=import-outside-toplevel
 
@@ -798,12 +798,12 @@ async def prepare_speeches_bulk_archive(
             archive_format=archive_format,
             result_store=result_store,
         )
-    except ResultStoreNotFound:
-        raise HTTPException(status_code=404, detail="Source ticket not found or expired")
+    except ResultStoreNotFound as e:
+        raise HTTPException(status_code=404, detail="Source ticket not found or expired") from e
     except ValueError as exc:
-        raise HTTPException(status_code=409, detail=str(exc))
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
 
-    celery_enabled: bool = ConfigValue("development.celery_enabled", default=False).resolve()
+    celery_enabled: bool = bool(ConfigValue("development.celery_enabled", default=False).resolve())
     if celery_enabled:
         import importlib  # pylint: disable=import-outside-toplevel
 
@@ -836,8 +836,8 @@ async def get_speeches_archive_status(
         if status.status == TicketStatus.PENDING.value:
             response.headers.update(_pending_retry_headers())
         return status
-    except ResultStoreNotFound:
-        raise HTTPException(status_code=404, detail="Archive ticket not found or expired")
+    except ResultStoreNotFound as e:
+        raise HTTPException(status_code=404, detail="Archive ticket not found or expired") from e
 
 
 @router.get(
@@ -873,8 +873,8 @@ async def download_speeches_bulk_archive(
     filename: str = f"speeches_archive_{archive_ticket_id}{suffix}"
     try:
         result_store.touch_ticket(archive_ticket_id)
-    except ResultStoreNotFound:
-        raise HTTPException(status_code=404, detail="Archive ticket not found or expired")
+    except ResultStoreNotFound as e:
+        raise HTTPException(status_code=404, detail="Archive ticket not found or expired") from e
     return FileResponse(path=str(ticket.artifact_path), media_type=media_type, filename=filename)
 
 

--- a/api_swedeb/api/v1/endpoints/tool_router.py
+++ b/api_swedeb/api/v1/endpoints/tool_router.py
@@ -7,6 +7,7 @@ from fastapi import BackgroundTasks, Body, Depends, HTTPException, Query, Respon
 from fastapi.responses import JSONResponse, StreamingResponse
 
 from api_swedeb.api.dependencies import (
+    get_archive_ticket_service,
     get_corpus_loader,
     get_cwb_corpus,
     get_cwb_corpus_opts,
@@ -20,6 +21,7 @@ from api_swedeb.api.dependencies import (
     get_word_trends_service,
 )
 from api_swedeb.api.params import CommonQueryParams
+from api_swedeb.api.services.archive_ticket_service import ArchiveTicketService
 from api_swedeb.api.services.corpus_loader import CorpusLoader
 from api_swedeb.api.services.download_service import DownloadService
 from api_swedeb.api.services.kwic_service import KWICService
@@ -42,6 +44,13 @@ from api_swedeb.core.configuration import ConfigValue
 from api_swedeb.mappers.word_trends import (
     search_hits_to_api_model,
     word_trends_to_api_model,
+)
+from api_swedeb.schemas.bulk_archive_schema import (
+    ARCHIVE_MEDIA_TYPES,
+    ARCHIVE_SUFFIXES,
+    ArchivePrepareResponse,
+    ArchiveTicketStatus,
+    BulkArchiveFormat,
 )
 from api_swedeb.schemas.kwic_schema import (
     KWICPageResult,
@@ -453,6 +462,106 @@ async def download_word_trend_speeches_archive(
     )
 
 
+# ---------------------------------------------------------------------------
+# Async bulk archive: word_trend_speeches
+# ---------------------------------------------------------------------------
+
+
+@router.post(
+    "/word_trend_speeches/archive/{ticket_id}",
+    response_model=ArchivePrepareResponse,
+    status_code=202,
+    summary="Prepare a bulk archive from a word trend speeches ticket",
+)
+async def prepare_word_trend_speeches_bulk_archive(
+    ticket_id: str,
+    background_tasks: BackgroundTasks,
+    archive_format: BulkArchiveFormat = Query(default=BulkArchiveFormat.jsonl_gz),
+    archive_ticket_service: ArchiveTicketService = Depends(get_archive_ticket_service),
+    result_store: ResultStore = Depends(get_result_store),
+    search_service: SearchService = Depends(get_search_service),
+) -> ArchivePrepareResponse:
+    """Start async archive generation for a ready word trend speeches ticket.
+
+    Returns 202 with an ``archive_ticket_id`` to poll for completion.
+    """
+    try:
+        response: ArchivePrepareResponse = archive_ticket_service.prepare(
+            source_ticket_id=ticket_id,
+            archive_format=archive_format,
+            result_store=result_store,
+        )
+    except ResultStoreNotFound:
+        raise HTTPException(status_code=404, detail="Source ticket not found or expired")
+    except ValueError as exc:
+        raise HTTPException(status_code=409, detail=str(exc))
+
+    celery_enabled: bool = ConfigValue("development.celery_enabled", default=False).resolve()
+    if celery_enabled:
+        import importlib  # pylint: disable=import-outside-toplevel
+
+        celery_tasks = importlib.import_module("api_swedeb.celery_tasks")
+        celery_tasks.execute_archive_task_celery_task.delay(response.archive_ticket_id)
+    else:
+        background_tasks.add_task(
+            archive_ticket_service.execute_archive_task,
+            archive_ticket_id=response.archive_ticket_id,
+            result_store=result_store,
+            search_service=search_service,
+        )
+
+    return response
+
+
+@router.get(
+    "/word_trend_speeches/archive/status/{archive_ticket_id}",
+    response_model=ArchiveTicketStatus,
+    summary="Poll the status of a word trend speeches bulk archive ticket",
+)
+async def get_word_trend_speeches_archive_status(
+    archive_ticket_id: str,
+    archive_ticket_service: ArchiveTicketService = Depends(get_archive_ticket_service),
+    result_store: ResultStore = Depends(get_result_store),
+) -> ArchiveTicketStatus:
+    try:
+        return archive_ticket_service.get_status(archive_ticket_id, result_store)
+    except ResultStoreNotFound:
+        raise HTTPException(status_code=404, detail="Archive ticket not found or expired")
+
+
+@router.get(
+    "/word_trend_speeches/archive/download/{archive_ticket_id}",
+    summary="Download a ready word trend speeches bulk archive",
+)
+async def download_word_trend_speeches_bulk_archive(
+    archive_ticket_id: str,
+    result_store: ResultStore = Depends(get_result_store),
+):
+    from fastapi.responses import FileResponse  # pylint: disable=import-outside-toplevel
+
+    try:
+        ticket: TicketMeta = result_store.require_ticket(archive_ticket_id)
+    except ResultStoreNotFound:
+        raise HTTPException(status_code=404, detail="Archive ticket not found or expired")
+
+    if ticket.status != TicketStatus.READY:
+        raise HTTPException(status_code=409, detail="Archive is not ready yet")
+    if ticket.artifact_path is None or not ticket.artifact_path.exists():
+        raise HTTPException(status_code=410, detail="Archive file no longer available")
+
+    archive_format_str: str = ticket.archive_format or BulkArchiveFormat.jsonl_gz.value
+    try:
+        archive_format = BulkArchiveFormat(archive_format_str)
+    except ValueError:
+        archive_format = BulkArchiveFormat.jsonl_gz
+
+    media_type: str = ARCHIVE_MEDIA_TYPES.get(archive_format, "application/octet-stream")
+    suffix: str = ARCHIVE_SUFFIXES.get(archive_format, f".{archive_format_str}")
+    filename: str = f"word_trend_speeches_archive_{archive_ticket_id}{suffix}"
+    result_store.touch_ticket(archive_ticket_id)
+    return FileResponse(path=str(ticket.artifact_path), media_type=media_type, filename=filename)
+
+
 @router.get("/word_trend_hits/{search}", response_model=SearchHits)
 async def get_word_hits(
     search: str,
@@ -649,6 +758,106 @@ async def download_speeches_archive_by_ticket(
         result_store=result_store,
         search_service=search_service,
     )
+
+
+# ---------------------------------------------------------------------------
+# Async bulk archive: speeches
+# ---------------------------------------------------------------------------
+
+
+@router.post(
+    "/speeches/archive/{ticket_id}",
+    response_model=ArchivePrepareResponse,
+    status_code=202,
+    summary="Prepare a bulk archive from a speeches ticket",
+)
+async def prepare_speeches_bulk_archive(
+    ticket_id: str,
+    background_tasks: BackgroundTasks,
+    archive_format: BulkArchiveFormat = Query(default=BulkArchiveFormat.jsonl_gz),
+    archive_ticket_service: ArchiveTicketService = Depends(get_archive_ticket_service),
+    result_store: ResultStore = Depends(get_result_store),
+    search_service: SearchService = Depends(get_search_service),
+) -> ArchivePrepareResponse:
+    """Start async archive generation for a ready speeches ticket.
+
+    Returns 202 with an ``archive_ticket_id`` to poll for completion.
+    """
+    try:
+        response: ArchivePrepareResponse = archive_ticket_service.prepare(
+            source_ticket_id=ticket_id,
+            archive_format=archive_format,
+            result_store=result_store,
+        )
+    except ResultStoreNotFound:
+        raise HTTPException(status_code=404, detail="Source ticket not found or expired")
+    except ValueError as exc:
+        raise HTTPException(status_code=409, detail=str(exc))
+
+    celery_enabled: bool = ConfigValue("development.celery_enabled", default=False).resolve()
+    if celery_enabled:
+        import importlib  # pylint: disable=import-outside-toplevel
+
+        celery_tasks = importlib.import_module("api_swedeb.celery_tasks")
+        celery_tasks.execute_archive_task_celery_task.delay(response.archive_ticket_id)
+    else:
+        background_tasks.add_task(
+            archive_ticket_service.execute_archive_task,
+            archive_ticket_id=response.archive_ticket_id,
+            result_store=result_store,
+            search_service=search_service,
+        )
+
+    return response
+
+
+@router.get(
+    "/speeches/archive/status/{archive_ticket_id}",
+    response_model=ArchiveTicketStatus,
+    summary="Poll the status of a speeches bulk archive ticket",
+)
+async def get_speeches_archive_status(
+    archive_ticket_id: str,
+    archive_ticket_service: ArchiveTicketService = Depends(get_archive_ticket_service),
+    result_store: ResultStore = Depends(get_result_store),
+) -> ArchiveTicketStatus:
+    try:
+        return archive_ticket_service.get_status(archive_ticket_id, result_store)
+    except ResultStoreNotFound:
+        raise HTTPException(status_code=404, detail="Archive ticket not found or expired")
+
+
+@router.get(
+    "/speeches/archive/download/{archive_ticket_id}",
+    summary="Download a ready speeches bulk archive",
+)
+async def download_speeches_bulk_archive(
+    archive_ticket_id: str,
+    result_store: ResultStore = Depends(get_result_store),
+):
+    from fastapi.responses import FileResponse  # pylint: disable=import-outside-toplevel
+
+    try:
+        ticket: TicketMeta = result_store.require_ticket(archive_ticket_id)
+    except ResultStoreNotFound:
+        raise HTTPException(status_code=404, detail="Archive ticket not found or expired")
+
+    if ticket.status != TicketStatus.READY:
+        raise HTTPException(status_code=409, detail="Archive is not ready yet")
+    if ticket.artifact_path is None or not ticket.artifact_path.exists():
+        raise HTTPException(status_code=410, detail="Archive file no longer available")
+
+    archive_format_str: str = ticket.archive_format or BulkArchiveFormat.jsonl_gz.value
+    try:
+        archive_format = BulkArchiveFormat(archive_format_str)
+    except ValueError:
+        archive_format = BulkArchiveFormat.jsonl_gz
+
+    media_type: str = ARCHIVE_MEDIA_TYPES.get(archive_format, "application/octet-stream")
+    suffix: str = ARCHIVE_SUFFIXES.get(archive_format, f".{archive_format_str}")
+    filename: str = f"speeches_archive_{archive_ticket_id}{suffix}"
+    result_store.touch_ticket(archive_ticket_id)
+    return FileResponse(path=str(ticket.artifact_path), media_type=media_type, filename=filename)
 
 
 @router.post("/speeches/download")

--- a/api_swedeb/api/v1/endpoints/tool_router.py
+++ b/api_swedeb/api/v1/endpoints/tool_router.py
@@ -491,10 +491,10 @@ async def prepare_word_trend_speeches_bulk_archive(
             archive_format=archive_format,
             result_store=result_store,
         )
-    except ResultStoreNotFound:
-        raise HTTPException(status_code=404, detail="Source ticket not found or expired")
+    except ResultStoreNotFound as e:
+        raise HTTPException(status_code=404, detail="Source ticket not found or expired") from e
     except ValueError as exc:
-        raise HTTPException(status_code=409, detail=str(exc))
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
 
     celery_enabled: bool = ConfigValue("development.celery_enabled", default=False).resolve()
     if celery_enabled:
@@ -520,13 +520,17 @@ async def prepare_word_trend_speeches_bulk_archive(
 )
 async def get_word_trend_speeches_archive_status(
     archive_ticket_id: str,
+    response: Response,
     archive_ticket_service: ArchiveTicketService = Depends(get_archive_ticket_service),
     result_store: ResultStore = Depends(get_result_store),
 ) -> ArchiveTicketStatus:
     try:
-        return archive_ticket_service.get_status(archive_ticket_id, result_store)
-    except ResultStoreNotFound:
-        raise HTTPException(status_code=404, detail="Archive ticket not found or expired")
+        status = archive_ticket_service.get_status(archive_ticket_id, result_store)
+        if status.status == TicketStatus.PENDING.value:
+            response.headers.update(_pending_retry_headers())
+        return status
+    except ResultStoreNotFound as e:
+        raise HTTPException(status_code=404, detail="Archive ticket not found or expired") from e
 
 
 @router.get(
@@ -541,9 +545,11 @@ async def download_word_trend_speeches_bulk_archive(
 
     try:
         ticket: TicketMeta = result_store.require_ticket(archive_ticket_id)
-    except ResultStoreNotFound:
-        raise HTTPException(status_code=404, detail="Archive ticket not found or expired")
+    except ResultStoreNotFound as e:
+        raise HTTPException(status_code=404, detail="Archive ticket not found or expired") from e
 
+    if ticket.status == TicketStatus.ERROR:
+        raise HTTPException(status_code=409, detail=ticket.error or "Archive preparation failed")
     if ticket.status != TicketStatus.READY:
         raise HTTPException(status_code=409, detail="Archive is not ready yet")
     if ticket.artifact_path is None or not ticket.artifact_path.exists():
@@ -558,7 +564,10 @@ async def download_word_trend_speeches_bulk_archive(
     media_type: str = ARCHIVE_MEDIA_TYPES.get(archive_format, "application/octet-stream")
     suffix: str = ARCHIVE_SUFFIXES.get(archive_format, f".{archive_format_str}")
     filename: str = f"word_trend_speeches_archive_{archive_ticket_id}{suffix}"
-    result_store.touch_ticket(archive_ticket_id)
+    try:
+        result_store.touch_ticket(archive_ticket_id)
+    except ResultStoreNotFound as e:
+        raise HTTPException(status_code=404, detail="Archive ticket not found or expired") from e
     return FileResponse(path=str(ticket.artifact_path), media_type=media_type, filename=filename)
 
 
@@ -818,11 +827,15 @@ async def prepare_speeches_bulk_archive(
 )
 async def get_speeches_archive_status(
     archive_ticket_id: str,
+    response: Response,
     archive_ticket_service: ArchiveTicketService = Depends(get_archive_ticket_service),
     result_store: ResultStore = Depends(get_result_store),
 ) -> ArchiveTicketStatus:
     try:
-        return archive_ticket_service.get_status(archive_ticket_id, result_store)
+        status = archive_ticket_service.get_status(archive_ticket_id, result_store)
+        if status.status == TicketStatus.PENDING.value:
+            response.headers.update(_pending_retry_headers())
+        return status
     except ResultStoreNotFound:
         raise HTTPException(status_code=404, detail="Archive ticket not found or expired")
 
@@ -839,9 +852,11 @@ async def download_speeches_bulk_archive(
 
     try:
         ticket: TicketMeta = result_store.require_ticket(archive_ticket_id)
-    except ResultStoreNotFound:
-        raise HTTPException(status_code=404, detail="Archive ticket not found or expired")
+    except ResultStoreNotFound as e:
+        raise HTTPException(status_code=404, detail="Archive ticket not found or expired") from e
 
+    if ticket.status == TicketStatus.ERROR:
+        raise HTTPException(status_code=409, detail=ticket.error or "Archive preparation failed")
     if ticket.status != TicketStatus.READY:
         raise HTTPException(status_code=409, detail="Archive is not ready yet")
     if ticket.artifact_path is None or not ticket.artifact_path.exists():
@@ -856,7 +871,10 @@ async def download_speeches_bulk_archive(
     media_type: str = ARCHIVE_MEDIA_TYPES.get(archive_format, "application/octet-stream")
     suffix: str = ARCHIVE_SUFFIXES.get(archive_format, f".{archive_format_str}")
     filename: str = f"speeches_archive_{archive_ticket_id}{suffix}"
-    result_store.touch_ticket(archive_ticket_id)
+    try:
+        result_store.touch_ticket(archive_ticket_id)
+    except ResultStoreNotFound:
+        raise HTTPException(status_code=404, detail="Archive ticket not found or expired")
     return FileResponse(path=str(ticket.artifact_path), media_type=media_type, filename=filename)
 
 

--- a/api_swedeb/celery_tasks.py
+++ b/api_swedeb/celery_tasks.py
@@ -12,6 +12,7 @@ import os
 
 from celery.signals import worker_init
 
+from api_swedeb.api.services.archive_ticket_service import execute_archive_task as _execute_archive_task
 from api_swedeb.api.services.kwic_ticket_service import execute_ticket_task as _execute_ticket_task
 from api_swedeb.api.services.speeches_ticket_service import (
     execute_speeches_ticket_task as _execute_speeches_ticket_task,
@@ -61,3 +62,14 @@ def execute_speeches_ticket_celery_task(self, ticket_id: str, selections: dict) 
     """Celery-wrapped speeches ticket execution."""
     self.update_state(state="PROGRESS", meta={"ticket_id": ticket_id})
     return _execute_speeches_ticket_task(ticket_id, selections)
+
+
+@celery_app.task(bind=True, name="api_swedeb.execute_archive_task")
+def execute_archive_task_celery_task(self, archive_ticket_id: str) -> dict:
+    """Celery-wrapped bulk archive generation.
+
+    Delegates to ``execute_archive_task`` which initialises per-worker singletons
+    (SearchService, ResultStore) and generates the archive file.
+    """
+    self.update_state(state="PROGRESS", meta={"archive_ticket_id": archive_ticket_id})
+    return _execute_archive_task(archive_ticket_id)

--- a/api_swedeb/schemas/bulk_archive_schema.py
+++ b/api_swedeb/schemas/bulk_archive_schema.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from datetime import datetime
+from enum import StrEnum
+from typing import Literal
+
+from pydantic import BaseModel
+
+
+class BulkArchiveFormat(StrEnum):
+    jsonl_gz = "jsonl_gz"
+    zip = "zip"
+    csv_gz = "csv_gz"
+
+    @classmethod
+    def _missing_(cls, value: object) -> "BulkArchiveFormat | None":
+        if isinstance(value, str):
+            normalized = value.lower().replace("-", "_").replace(".", "_")
+            for member in cls:
+                if member.value == normalized:
+                    return member
+        return None
+
+
+ARCHIVE_SUFFIXES: dict[BulkArchiveFormat, str] = {
+    BulkArchiveFormat.jsonl_gz: ".jsonl.gz",
+    BulkArchiveFormat.zip: ".zip",
+    BulkArchiveFormat.csv_gz: ".csv.gz",
+}
+
+ARCHIVE_MEDIA_TYPES: dict[BulkArchiveFormat, str] = {
+    BulkArchiveFormat.jsonl_gz: "application/gzip",
+    BulkArchiveFormat.zip: "application/zip",
+    BulkArchiveFormat.csv_gz: "application/gzip",
+}
+
+
+class ArchivePrepareResponse(BaseModel):
+    archive_ticket_id: str
+    status: Literal["pending"]
+    source_ticket_id: str
+    archive_format: str
+    retry_after: int
+
+
+class ArchiveTicketStatus(BaseModel):
+    archive_ticket_id: str
+    status: Literal["pending", "ready", "error"]
+    source_ticket_id: str | None = None
+    archive_format: str | None = None
+    speech_count: int | None = None
+    expires_at: datetime
+    error: str | None = None

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -141,6 +141,11 @@ The `config.yml` structure includes the following operational sections:
 - `ticket_state_backend_url` - Shared backend used for ticket metadata and counters; production should point this at the same Redis deployment used by the workers
 - `ticket_state_prefix` - Key prefix for shared ticket metadata; use a deployment-specific namespace when multiple environments share one Redis server
 
+**`cache`** - Bulk archive generation
+- Archive artifacts are stored under `cache.root_dir/archives/` as either `<archive_ticket_id>.jsonl.gz` or `<archive_ticket_id>.zip`, depending on the `archive_format` query parameter
+- Archive artifacts share the same `max_artifact_bytes` capacity pool and `result_ttl_seconds` TTL as feather result artifacts; they are evicted and cleaned up by the same background cleanup loop
+- No separate `archive_ttl_seconds` key is needed; tune `result_ttl_seconds` and `max_artifact_bytes` together to accommodate the expected artifact sizes
+
 **`celery`** - Background task queue configuration (required for production ticket execution)
 - `broker_url` - Redis connection URL for task queue
 - `result_backend` - Redis connection URL for result storage
@@ -156,6 +161,9 @@ The `config.yml` structure includes the following operational sections:
 - The `cache.root_dir` volume must be shared between API and Celery worker containers so ticket artifacts are accessible across processes
 - Cache settings apply globally to all ticket-based endpoints (KWIC, speeches, and word-trend speeches)
 - Ticket artifacts are stored as feather files under `cache.root_dir`
+- Archive artifacts are stored as `.jsonl.gz` or `.zip` files under `cache.root_dir/archives/`; this subdirectory is created automatically at startup
+- Both feather and archive artifacts share the same `max_artifact_bytes` capacity pool; size `max_artifact_bytes` to accommodate both (feather files are typically small; a 50k-speech `.jsonl.gz` is approximately 50–200 MB compressed)
+- Partial archive files (`.partial` suffix) written by a failed task are cleaned up automatically on the next startup or background cleanup cycle
 - Cleanup runs automatically at `cleanup_interval_seconds` frequency to remove expired tickets
 - When `ticket_state_backend_url` is set, pending-job counts, artifact-byte limits, and ticket metadata are enforced through that shared backend rather than per-process memory
 - If multiple environments point at the same Redis deployment, `ticket_state_prefix` must differ so ticket state does not collide across environments

--- a/docs/change_requests/TICKET_BASED_BULK_ARCHIVE_GENERATION.md
+++ b/docs/change_requests/TICKET_BASED_BULK_ARCHIVE_GENERATION.md
@@ -321,11 +321,84 @@ Keep ZIP as a compatibility option, but stop treating synchronous ZIP streaming 
   - `GET` download returns `409` for a pending archive ticket
   - Tests for both word-trend-speeches and speeches archive routes
 
-### 12. Frontend (out of scope for this checklist — tracked separately)
+### 12. Frontend wiring
 
-- [ ] Update word-trend speeches and speeches download controls to use the prepare/status/download flow
-- [ ] Show preparation progress to the user while archive ticket is pending
-- [ ] Fall back gracefully if archive preparation fails
+The frontend currently calls the legacy single-step streaming endpoints
+(`GET /tools/speeches/archive/{ticket_id}` and
+`GET /tools/word_trend_speeches/archive/{ticket_id}`).  These are kept in the
+backend for backward compatibility, but the new ticket-based flow (`POST` →
+poll status → `GET` download) should replace them.
+
+The existing `ticketPolling.js` helper (`getTicketPollDelayMs`, constants) and
+the pattern used by `speechesDataStore` / `wordTrendsDataStore` for
+result-ticket polling are the building blocks.
+
+#### 12a. Shared archive polling helper (`src/stores/ticketPolling.js`)
+
+- [x] Create `pollArchiveTicket(api, statusUrl, { maxAttempts, onStatus })` — loops
+  `GET status/{archive_ticket_id}`, waits for `ready` or `error`, uses
+  `Retry-After` header / `retry_after` field for back-off (reuse
+  `getTicketPollDelayMs` from `ticketPolling.js`) — added inline to `ticketPolling.js`
+- [x] Helper should propagate `error` status as a thrown/rejected error with the
+  server's `error` field as the message
+
+#### 12b. `wordTrendsDataStore` — replace `downloadSpeechesZip`
+
+- [x] Add `archiveTicketId`, `archiveTicketStatus` state fields (similar to
+  `ticketId` / `ticketStatus`)
+- [x] Add `resetArchiveTicketState()` action
+- [x] Replace the body of `downloadSpeechesZip` with the three-step flow:
+  1. `POST /tools/word_trend_speeches/archive/{this.ticketId}?archive_format=zip`
+     → store returned `archive_ticket_id`
+  2. Poll `GET /tools/word_trend_speeches/archive/status/{archive_ticket_id}`
+     until `ready` (use `pollArchiveTicket`)
+  3. `GET /tools/word_trend_speeches/archive/download/{archive_ticket_id}` →
+     trigger download via `downloadDataStore().setupDownload(...)`
+- [x] `isArchivePending` not exposed as a separate property — the component wraps
+  the call in `runTrackedDownload(downloadKeys.zip, ...)`, so `isDownloadActive`
+  already reflects the full operation (including polling)
+- [x] On `404` from prepare or download: reset archive state and show
+  `i18n.accessibility.ticketExpired`
+- [x] On `error` status: show the server error message
+
+#### 12c. `downloadDataStore` — replace `downloadSpeechesZipByTicket`
+
+- [x] Add `archiveTicketId`, `archiveTicketStatus` state fields
+- [x] Add `resetArchiveTicketState()` action
+- [x] Replace the body of `downloadSpeechesZipByTicket(ticketId)` with the
+  three-step flow:
+  1. `POST /tools/speeches/archive/{ticketId}?archive_format=zip`
+     → store returned `archive_ticket_id`
+  2. Poll `GET /tools/speeches/archive/status/{archive_ticket_id}`
+  3. `GET /tools/speeches/archive/download/{archive_ticket_id}` → download
+- [x] `isArchivePending` not needed as a separate property — callers (`speechesTable.vue`,
+  `kwicDataTable.vue`) both use `runTrackedDownload`, so `isDownloadActive` covers
+  the full operation including polling
+
+#### 12d. `speechesTable.vue` — reflect archive-pending state
+
+- [x] No template changes needed — the call to `downloadSpeechesZipByTicket`
+  is already wrapped in `runTrackedDownload(downloadKeys.zip, ...)`, which keeps
+  `isDownloadActive(downloadKeys.zip)` true for the full duration (including
+  archive polling). Same applies to `kwicDataTable.vue` and
+  `wordTrendsSpeechTable.vue`.
+
+#### 12e. i18n
+
+- [x] No new translation keys needed — `runTrackedDownload` uses the existing
+  `downloadFeedback.preparing` message for the spinner notification
+- [x] Existing `i18n.accessibility.ticketExpired` key reused for `404` responses
+  from archive endpoints
+
+#### 12f. Validation
+
+- [x] `pnpm lint` passes after all frontend changes
+- [ ] Manual smoke test: trigger a large word-trend-speeches search, click
+  download ZIP, confirm the button enters a loading state, the archive is
+  generated, and the file is saved
+- [ ] Manual smoke test: same for speeches download ZIP via `speechesTable`
+- [ ] Confirm fallback: if the backend returns an error status, the UI shows
+  the error message and the button is re-enabled
 
 ### 13. Documentation and config
 

--- a/docs/change_requests/TICKET_BASED_BULK_ARCHIVE_GENERATION.md
+++ b/docs/change_requests/TICKET_BASED_BULK_ARCHIVE_GENERATION.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-- **In progress** — backend implementation complete on branch `ticket-based-buld-archive-generation`; frontend integration pending
+- **In progress** — backend implementation complete on branch `ticket-based-bulk-archive-generation`; frontend integration pending
 - Scope: Backend archive generation for large speech downloads
 - Goal: Move expensive archive creation out of synchronous HTTP download requests
 

--- a/docs/change_requests/TICKET_BASED_BULK_ARCHIVE_GENERATION.md
+++ b/docs/change_requests/TICKET_BASED_BULK_ARCHIVE_GENERATION.md
@@ -2,9 +2,24 @@
 
 ## Status
 
-- Proposed change request
+- **In progress** — backend implementation complete on branch `ticket-based-buld-archive-generation`; frontend integration pending
 - Scope: Backend archive generation for large speech downloads
 - Goal: Move expensive archive creation out of synchronous HTTP download requests
+
+### Implementation progress
+
+| Deliverable                                                                                                | Status    |
+|------------------------------------------------------------------------------------------------------------|-----------|
+| `BulkArchiveFormat`, `ArchivePrepareResponse`, `ArchiveTicketStatus` schemas (`bulk_archive_schema.py`)    | ✅ Done    |
+| `TicketMeta` extended with `source_ticket_id` and `archive_format`; `create_ticket()` accepts new fields   | ✅ Done    |
+| `ResultStore`: `archive_artifact_path()`, `store_archive_ready()`, archive cleanup and capacity accounting | ✅ Done    |
+| `write_jsonl_gz()` and `write_zip()` atomic archive writers in `download_service.py`                       | ✅ Done    |
+| `ArchiveTicketService`: `prepare()`, `execute_archive_task()`, `get_status()`                              | ✅ Done    |
+| Celery task `api_swedeb.execute_archive_task` in `celery_tasks.py`                                         | ✅ Done    |
+| `AppContainer` and `dependencies.py` wired with `archive_ticket_service`                                   | ✅ Done    |
+| 6 new endpoints: `POST`/`GET status`/`GET download` for `word_trend_speeches` and `speeches`               | ✅ Done    |
+| Frontend download controls updated to show archive preparation status                                      | ❌ Pending |
+| Benchmark large-result behavior and document format recommendation                                         | ❌ Pending |
 
 ## Summary
 
@@ -204,115 +219,106 @@ Keep ZIP as a compatibility option, but stop treating synchronous ZIP streaming 
 
 ### 1. Archive format enum
 
-- [ ] Add `BulkArchiveFormat` enum (or extend `DownloadFormat`) in `tool_router.py` or a new `schemas/bulk_archive_schema.py`:
+- [x] Add `BulkArchiveFormat` enum (or extend `DownloadFormat`) in `tool_router.py` or a new `schemas/bulk_archive_schema.py`:
   - Values: `jsonl_gz` (default), `zip`
   - Match normalization pattern from `create_download_service()` in `download_service.py`
 
 ### 2. Archive ticket metadata
 
-- [ ] Add archive-specific fields to `TicketMeta` in `result_store.py` (slots=True):
+- [x] Add archive-specific fields to `TicketMeta` in `result_store.py` (slots=True):
   - `source_ticket_id: str | None = None` — ID of the source result ticket
   - `archive_format: str | None = None` — requested format (`jsonl.gz` or `zip`)
-- [ ] Update `TicketStateStore` serialization/deserialization in `ticket_state_store.py` to include the new fields
-- [ ] Verify existing `TicketMeta` round-trips are not broken by new optional fields
+- [x] Update `TicketStateStore` serialization/deserialization in `result_store.py` to include the new fields
+- [x] Verify existing `TicketMeta` round-trips are not broken by new optional fields
 
 ### 3. Archive artifact storage
 
-- [ ] Decide whether archive artifacts share the same `ResultStore` root or live under a sibling path (e.g. `root_dir/archives/`). Record the decision in the doc.
-- [ ] Add `_archive_artifact_path(archive_ticket_id: str) -> Path` helper to `ResultStore` (or reuse `_artifact_path` with a distinct prefix)
-- [ ] Add `store_archive_ready(archive_ticket_id, path, manifest)` to `ResultStore`:
-  - Write completed archive file atomically (partial → final rename)
-  - Update ticket to `READY` with `artifact_path` set
-- [ ] Ensure `cleanup_expired()` deletes archive artifact files the same way it handles result artifacts
-- [ ] Ensure archive artifact bytes are counted in capacity accounting (`max_artifact_bytes`)
+- [x] Decision: archive artifacts live under `root_dir/archives/` (distinct from result feather artifacts under `root_dir/`).
+- [x] Add `archive_artifact_path(archive_ticket_id: str, archive_format: str) -> Path` helper to `ResultStore`
+- [x] Add `store_archive_ready(archive_ticket_id, artifact_path, manifest_meta, total_hits)` to `ResultStore`:
+  - Artifact must already exist at `artifact_path` (writer does the atomic rename)
+  - Updates ticket to `READY` with `artifact_path` set
+- [x] Ensure `_cleanup_partial_files_locked()` also cleans `root_dir/archives/` partial files
+- [x] Ensure archive artifact bytes are counted in capacity accounting (`max_artifact_bytes`)
 
 ### 4. `jsonl.gz` archive writer
 
-- [ ] Add `write_jsonl_gz(speech_ids, search_service, dest_path)` helper in `download_service.py` (or a new `archive_writer.py`):
-  - Stream `search_service.get_speeches_text_batch(speech_ids)` in batches
-  - Write `gzip.GzipFile(compresslevel=1)` with one JSON-encoded speech per line
-  - Use atomic write: write to `.partial` path, rename to final on success
-  - Remove `.partial` path on failure
-- [ ] Add corresponding `write_zip(speech_ids, search_service, dest_path)` with the same atomic-write contract
+- [x] Add `write_jsonl_gz(speech_ids, search_service, dest_path, manifest_meta, compresslevel)` in `download_service.py`:
+  - Streams `search_service.get_speeches_text_batch(speech_ids)`
+  - Writes `gzip.open(compresslevel=1)` with one JSON-encoded speech per line
+  - Atomic write: write to `.partial` path, rename to final on success
+  - Removes `.partial` on failure
+- [x] Add `write_zip(speech_ids, search_service, dest_path, manifest_meta, compresslevel)` with the same atomic-write contract
 
 ### 5. Archive ticket service
 
-- [ ] Create `api_swedeb/api/services/archive_ticket_service.py` with `ArchiveTicketService`:
-  - `prepare(source_ticket_id, archive_format, result_store) -> TicketMeta`:
-    - Validate source ticket is `READY` via `result_store.require_ticket(source_ticket_id)`
-    - Create archive ticket with `result_store.create_ticket(query_meta=..., source_ticket_id=..., archive_format=...)`
-    - Dispatch archive generation (Celery or local)
-    - Return the new archive ticket meta
-  - `get_status(archive_ticket_id, result_store) -> ArchiveTicketStatus`:
-    - Delegate to `result_store.require_ticket(archive_ticket_id)`
-    - Map to status schema
+- [x] Create `api_swedeb/api/services/archive_ticket_service.py` with `ArchiveTicketService`:
+  - `prepare(source_ticket_id, archive_format, result_store) -> ArchivePrepareResponse`:
+    - Validates source ticket is `READY`
+    - Creates archive ticket via `result_store.create_ticket(source_ticket_id=..., archive_format=...)`
+    - Returns `ArchivePrepareResponse` (dispatch happens in the route)
+  - `get_status(archive_ticket_id, result_store) -> ArchiveTicketStatus`
   - `execute_archive_task(archive_ticket_id, result_store, search_service)`:
-    - Load `speech_ids` from source ticket metadata
-    - Generate archive artifact (call `write_jsonl_gz` or `write_zip` based on format)
-    - Call `result_store.store_archive_ready(archive_ticket_id, path, manifest_meta)`
-    - On failure call `result_store.store_error(archive_ticket_id, message=...)`
-- [ ] Register `get_archive_ticket_service()` singleton factory in `api_swedeb/api/dependencies.py`
+    - Loads `speech_ids` from source ticket
+    - Calls `write_jsonl_gz` or `write_zip`
+    - Calls `result_store.store_archive_ready(...)` on success
+    - Calls `result_store.store_error(...)` on failure
+- [x] Register `get_archive_ticket_service()` singleton factory in `api_swedeb/api/dependencies.py`
 
 ### 6. Celery task
 
-- [ ] Add `generate_archive_task` in `celery_tasks.py` following the pattern of existing ticket tasks:
-  - Accept `archive_ticket_id`, instantiate services, call `execute_archive_task`
-  - Handle exceptions: call `store_error` on unhandled exceptions
+- [x] Add `execute_archive_task_celery_task` in `celery_tasks.py` (task name `api_swedeb.execute_archive_task`):
+  - Accepts `archive_ticket_id`, delegates to `execute_archive_task()` worker entry point
+  - Worker-side singletons (`_get_worker_search_service`, `_get_worker_result_store`) in `archive_ticket_service.py`
 
 ### 7. Schemas
 
-- [ ] Add `ArchiveTicketStatus` response schema in `api_swedeb/schemas/` (or extend an existing schema module):
+- [x] Add `ArchiveTicketStatus` response schema in `api_swedeb/schemas/bulk_archive_schema.py`:
   - Fields: `archive_ticket_id`, `status`, `source_ticket_id`, `archive_format`, `speech_count`, `expires_at`, `error`
-- [ ] Add `ArchivePrepareResponse` schema:
-  - Fields: `archive_ticket_id`, `status`, `retry_after`
+- [x] Add `ArchivePrepareResponse` schema:
+  - Fields: `archive_ticket_id`, `status`, `source_ticket_id`, `archive_format`, `retry_after`
 
 ### 8. Word-trend speeches archive endpoints
 
-- [ ] Add to `tool_router.py`:
-  - `POST /word_trend_speeches/archive/{ticket_id}` — prepare endpoint:
-    - Accept `format: BulkArchiveFormat = jsonl_gz` query param
-    - Call `archive_ticket_service.prepare(...)`
-    - Return `202 Accepted` with `ArchivePrepareResponse`
-    - Reject missing, pending, or failed source tickets with `404`/`409`
-  - `GET /word_trend_speeches/archive/status/{archive_ticket_id}` — status endpoint:
-    - Call `archive_ticket_service.get_status(...)`
-    - Return `202` if pending, `200` if ready, `409` if failed
-  - `GET /word_trend_speeches/archive/download/{archive_ticket_id}` — download endpoint:
-    - Require `READY` status via `_require_ready_ticket`
-    - Serve completed artifact with `FileResponse` (no recompression)
-    - Set `Content-Disposition` with format-appropriate filename and extension
-- [ ] Deprecate or keep the existing `GET /word_trend_speeches/archive/{ticket_id}` synchronous endpoint; mark it as legacy if keeping it
+- [x] Add to `tool_router.py`:
+  - `POST /word_trend_speeches/archive/{ticket_id}` — returns `202 Accepted` with `ArchivePrepareResponse`
+  - `GET /word_trend_speeches/archive/status/{archive_ticket_id}` — returns `ArchiveTicketStatus`
+  - `GET /word_trend_speeches/archive/download/{archive_ticket_id}` — serves completed artifact via `FileResponse`
+- [x] Existing `GET /word_trend_speeches/archive/{ticket_id}` synchronous endpoint kept as legacy
 
 ### 9. Speeches archive endpoints
 
-- [ ] Add the same three endpoints for speeches:
+- [x] Add the same three endpoints for speeches:
   - `POST /speeches/archive/{ticket_id}`
   - `GET /speeches/archive/status/{archive_ticket_id}`
   - `GET /speeches/archive/download/{archive_ticket_id}`
-- [ ] Reuse `ArchiveTicketService` — no speeches-specific service subclass needed
+- [x] Reuses `ArchiveTicketService` — no speeches-specific service subclass needed
 
 ### 10. Unit tests
 
-- [ ] `tests/api_swedeb/api/services/test_archive_ticket_service.py`:
+- [x] `tests/api_swedeb/api/services/test_archive_ticket_service.py`:
   - `prepare()` returns `202` ticket for a ready source ticket
   - `prepare()` raises `ResultStoreNotFound` for a missing source ticket
   - `prepare()` raises appropriate error for a pending or failed source ticket
   - `execute_archive_task()` writes a valid `jsonl.gz` and marks ticket ready
   - `execute_archive_task()` marks ticket failed and cleans up partial file on error
   - `get_status()` returns correct status for pending, ready, and failed archive tickets
-- [ ] `tests/api_swedeb/api/services/test_result_store.py`:
+- [x] `tests/api_swedeb/api/services/test_result_store.py` (covered in `test_archive_ticket_service.py`):
   - Archive artifact path is distinct from result artifact path
   - Cleanup removes archive artifact file when archive ticket expires
   - Archive artifact bytes count toward `max_artifact_bytes`
 
 ### 11. Endpoint tests
 
-- [ ] `tests/api_swedeb/api/test_tool_router.py` (or equivalent):
+- [x] `tests/api_swedeb/api/test_archive_endpoints.py`:
   - `POST` prepare returns `202` with `archive_ticket_id`
   - `POST` prepare returns `404` for missing source ticket
-  - `GET` status returns `202` while pending, `200` when ready
-  - `GET` download returns the file content for a ready archive ticket
+  - `POST` prepare returns `409` for pending source ticket
+  - `GET` status returns pending/ready status
+  - `GET` status returns `404` for unknown archive ticket
+  - `GET` download returns the file content for a ready archive ticket (valid jsonl.gz)
   - `GET` download returns `404` for an expired or missing archive ticket
+  - `GET` download returns `409` for a pending archive ticket
   - Tests for both word-trend-speeches and speeches archive routes
 
 ### 12. Frontend (out of scope for this checklist — tracked separately)
@@ -323,8 +329,8 @@ Keep ZIP as a compatibility option, but stop treating synchronous ZIP streaming 
 
 ### 13. Documentation and config
 
-- [ ] Add `docs/OPERATIONS.md` note on archive artifact storage, capacity limits, and TTL behavior
-- [ ] Update `config/config.yml` if any new cache keys are needed for archive artifacts (e.g. separate `archive_ttl_seconds`)
-- [ ] Mirror any new config keys in `tests/config.yml`
+- [x] Add `docs/OPERATIONS.md` note on archive artifact storage, capacity limits, and TTL behavior
+- [x] No new `config/config.yml` keys needed — archive artifacts share the existing `cache.*` settings (`result_ttl_seconds`, `max_artifact_bytes`, `root_dir`); doc note added to `OPERATIONS.md`
+- [x] No `tests/config.yml` changes needed (no new keys)
 - [ ] Benchmark `jsonl.gz` versus ZIP for a representative large ticket (e.g. 50k speeches) and record results
 - [ ] Update this document's Status section to "Implemented" when the PR merges

--- a/tests/api_swedeb/api/services/test_archive_ticket_service.py
+++ b/tests/api_swedeb/api/services/test_archive_ticket_service.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import asyncio
+import csv
 import gzip
+import io
 import json
 import zipfile
 from dataclasses import replace
@@ -78,6 +80,12 @@ def test_archive_artifact_path_zip_has_zip_suffix(tmp_path):
     store = make_result_store(tmp_path)
     path = store.archive_artifact_path("some-ticket-id", "zip")
     assert path.name == "some-ticket-id.zip"
+
+
+def test_archive_artifact_path_csv_gz_has_csv_gz_suffix(tmp_path):
+    store = make_result_store(tmp_path)
+    path = store.archive_artifact_path("some-ticket-id", "csv_gz")
+    assert path.name == "some-ticket-id.csv.gz"
 
 
 def test_archive_artifact_path_distinct_from_feather_artifact(tmp_path):
@@ -400,6 +408,62 @@ def test_execute_archive_task_zip_marks_ticket_ready(tmp_path):
         assert ready.status == TicketStatus.READY
         assert ready.artifact_path is not None
         assert zipfile.is_zipfile(str(ready.artifact_path))
+    finally:
+        asyncio.run(store.shutdown())
+
+
+def test_execute_archive_task_csv_gz_marks_ticket_ready(tmp_path):
+    store = make_result_store(tmp_path)
+    service = ArchiveTicketService()
+    search_service = make_mock_search_service()
+
+    asyncio.run(store.startup())
+    try:
+        source = make_ready_source_ticket(store)
+        archive_ticket = store.create_ticket(source_ticket_id=source.ticket_id, archive_format="csv_gz")
+
+        service.execute_archive_task(
+            archive_ticket_id=archive_ticket.ticket_id,
+            result_store=store,
+            search_service=search_service,
+        )
+
+        ready = store.require_ticket(archive_ticket.ticket_id)
+        assert ready.status == TicketStatus.READY
+        assert ready.artifact_path is not None
+        assert ready.artifact_path.exists()
+        assert ready.artifact_path.suffix == ".gz"
+        assert ready.total_hits == len(SAMPLE_SPEECH_IDS)
+    finally:
+        asyncio.run(store.shutdown())
+
+
+def test_execute_archive_task_csv_gz_output_is_valid(tmp_path):
+    store = make_result_store(tmp_path)
+    service = ArchiveTicketService()
+    search_service = make_mock_search_service()
+
+    asyncio.run(store.startup())
+    try:
+        source = make_ready_source_ticket(store)
+        archive_ticket = store.create_ticket(source_ticket_id=source.ticket_id, archive_format="csv_gz")
+
+        service.execute_archive_task(
+            archive_ticket_id=archive_ticket.ticket_id,
+            result_store=store,
+            search_service=search_service,
+        )
+
+        ready = store.require_ticket(archive_ticket.ticket_id)
+        with gzip.open(str(ready.artifact_path), "rt", encoding="utf-8", newline="") as gz:
+            rows = list(csv.reader(gz))
+
+        header, *data_rows = rows
+        assert header == ["speech_id", "speaker_name", "text"]
+        assert [r[0] for r in data_rows] == [sid for sid, _ in SAMPLE_SPEECHES_TEXT]
+        assert [r[2] for r in data_rows] == [text for _, text in SAMPLE_SPEECHES_TEXT]
+        speaker_names = {"i-1": "Alice", "i-2": "Bob", "i-3": "Carol"}
+        assert [r[1] for r in data_rows] == [speaker_names[sid] for sid, _ in SAMPLE_SPEECHES_TEXT]
     finally:
         asyncio.run(store.shutdown())
 

--- a/tests/api_swedeb/api/services/test_archive_ticket_service.py
+++ b/tests/api_swedeb/api/services/test_archive_ticket_service.py
@@ -1,0 +1,533 @@
+"""Tests for ArchiveTicketService and ResultStore archive paths."""
+
+from __future__ import annotations
+
+import asyncio
+import gzip
+import json
+import zipfile
+from dataclasses import replace
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+from api_swedeb.api.services.archive_ticket_service import ArchiveTicketService
+from api_swedeb.api.services.result_store import (
+    ResultStore,
+    ResultStoreNotFound,
+    TicketMeta,
+    TicketStatus,
+)
+from api_swedeb.schemas.bulk_archive_schema import BulkArchiveFormat
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+SAMPLE_SPEECH_IDS = ["i-1", "i-2", "i-3"]
+SAMPLE_SPEECHES_TEXT = [("i-1", "text one"), ("i-2", "text two"), ("i-3", "text three")]
+
+
+def make_result_store(tmp_path: Path) -> ResultStore:
+    return ResultStore(
+        root_dir=tmp_path,
+        result_ttl_seconds=600,
+        cleanup_interval_seconds=0,
+        max_artifact_bytes=10_000_000,
+        max_pending_jobs=10,
+        max_page_size=500,
+    )
+
+
+def make_mock_search_service(speeches: list[tuple[str, str]] | None = None) -> MagicMock:
+    service = MagicMock()
+    service.get_speeches_text_batch.return_value = speeches if speeches is not None else SAMPLE_SPEECHES_TEXT
+    service.get_speaker_names.return_value = {"i-1": "Alice", "i-2": "Bob", "i-3": "Carol"}
+    return service
+
+
+def make_ready_source_ticket(store: ResultStore, speech_ids: list[str] | None = None) -> TicketMeta:
+    """Create a READY source ticket with speech_ids already stored."""
+    ids = speech_ids if speech_ids is not None else SAMPLE_SPEECH_IDS
+    ticket = store.create_ticket(query_meta={"search": ["demokrati"]})
+    frame = pd.DataFrame([{"speech_id": sid, "node_word": "demokrati"} for sid in ids])
+    store.store_ready(
+        ticket.ticket_id,
+        df=frame,
+        speech_ids=ids,
+        manifest_meta={"search": ["demokrati"], "total_hits": len(ids)},
+    )
+    return store.require_ticket(ticket.ticket_id)
+
+
+# ---------------------------------------------------------------------------
+# Tests: ResultStore archive paths
+# ---------------------------------------------------------------------------
+
+
+def test_archive_artifact_path_is_under_archives_subdir(tmp_path):
+    store = make_result_store(tmp_path)
+    path = store.archive_artifact_path("some-ticket-id", "jsonl_gz")
+    assert path.parent == tmp_path / "archives"
+    assert path.name == "some-ticket-id.jsonl.gz"
+
+
+def test_archive_artifact_path_zip_has_zip_suffix(tmp_path):
+    store = make_result_store(tmp_path)
+    path = store.archive_artifact_path("some-ticket-id", "zip")
+    assert path.name == "some-ticket-id.zip"
+
+
+def test_archive_artifact_path_distinct_from_feather_artifact(tmp_path):
+    store = make_result_store(tmp_path)
+    asyncio.run(store.startup())
+    try:
+        ticket = store.create_ticket()
+        archive_path = store.archive_artifact_path(ticket.ticket_id, "jsonl_gz")
+        feather_path = store._artifact_path(ticket.ticket_id)
+        assert archive_path != feather_path
+        assert archive_path.parent != feather_path.parent
+    finally:
+        asyncio.run(store.shutdown())
+
+
+def test_startup_creates_archives_subdir(tmp_path):
+    store = make_result_store(tmp_path)
+    asyncio.run(store.startup())
+    try:
+        assert (tmp_path / "archives").is_dir()
+    finally:
+        asyncio.run(store.shutdown())
+
+
+def test_store_archive_ready_updates_ticket_to_ready(tmp_path):
+    store = make_result_store(tmp_path)
+    asyncio.run(store.startup())
+    try:
+        source = make_ready_source_ticket(store)
+        archive_ticket = store.create_ticket(source_ticket_id=source.ticket_id, archive_format="jsonl_gz")
+        # Write a fake archive file
+        dest = store.archive_artifact_path(archive_ticket.ticket_id, "jsonl_gz")
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_bytes(b"fake archive content")
+
+        updated = store.store_archive_ready(
+            archive_ticket.ticket_id,
+            artifact_path=dest,
+            manifest_meta={"speech_count": 3},
+            total_hits=3,
+        )
+
+        assert updated.status == TicketStatus.READY
+        assert updated.artifact_path == dest
+        assert updated.artifact_bytes == len(b"fake archive content")
+        assert updated.total_hits == 3
+        assert updated.manifest_meta == {"speech_count": 3}
+    finally:
+        asyncio.run(store.shutdown())
+
+
+def test_store_archive_ready_counts_bytes_toward_capacity(tmp_path):
+    store = make_result_store(tmp_path)
+    asyncio.run(store.startup())
+    try:
+        source = make_ready_source_ticket(store)
+        archive_ticket = store.create_ticket(source_ticket_id=source.ticket_id, archive_format="jsonl_gz")
+        dest = store.archive_artifact_path(archive_ticket.ticket_id, "jsonl_gz")
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        payload = b"x" * 500
+        dest.write_bytes(payload)
+
+        store.store_archive_ready(archive_ticket.ticket_id, artifact_path=dest, total_hits=1)
+
+        ready = store.require_ticket(archive_ticket.ticket_id)
+        assert ready.artifact_bytes == 500
+    finally:
+        asyncio.run(store.shutdown())
+
+
+def test_store_archive_ready_raises_if_file_missing(tmp_path):
+    store = make_result_store(tmp_path)
+    asyncio.run(store.startup())
+    try:
+        source = make_ready_source_ticket(store)
+        archive_ticket = store.create_ticket(source_ticket_id=source.ticket_id, archive_format="jsonl_gz")
+        missing_path = store.archive_artifact_path(archive_ticket.ticket_id, "jsonl_gz")
+
+        with pytest.raises(ResultStoreNotFound):
+            store.store_archive_ready(archive_ticket.ticket_id, artifact_path=missing_path)
+    finally:
+        asyncio.run(store.shutdown())
+
+
+def test_cleanup_removes_archive_artifact_when_ticket_expires(tmp_path):
+    store = make_result_store(tmp_path)
+    asyncio.run(store.startup())
+    try:
+        source = make_ready_source_ticket(store)
+        archive_ticket = store.create_ticket(source_ticket_id=source.ticket_id, archive_format="jsonl_gz")
+        dest = store.archive_artifact_path(archive_ticket.ticket_id, "jsonl_gz")
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_bytes(b"archive data")
+        store.store_archive_ready(archive_ticket.ticket_id, artifact_path=dest, total_hits=1)
+
+        # Force expiry
+        expired = replace(
+            store.require_ticket(archive_ticket.ticket_id),
+            expires_at=store.require_ticket(archive_ticket.ticket_id).created_at,
+        )
+        store._tickets[archive_ticket.ticket_id] = expired
+
+        store.cleanup_expired()
+
+        assert not dest.exists()
+        with pytest.raises(ResultStoreNotFound):
+            store.require_ticket(archive_ticket.ticket_id)
+    finally:
+        asyncio.run(store.shutdown())
+
+
+def test_create_ticket_stores_source_ticket_id_and_archive_format(tmp_path):
+    store = make_result_store(tmp_path)
+    asyncio.run(store.startup())
+    try:
+        ticket = store.create_ticket(source_ticket_id="src-123", archive_format="zip")
+        loaded = store.require_ticket(ticket.ticket_id)
+        assert loaded.source_ticket_id == "src-123"
+        assert loaded.archive_format == "zip"
+    finally:
+        asyncio.run(store.shutdown())
+
+
+def test_cleanup_partial_archive_files_on_startup(tmp_path):
+    archives_dir = tmp_path / "archives"
+    archives_dir.mkdir(parents=True)
+    partial = archives_dir / "some-ticket.jsonl.gz.partial"
+    partial.write_bytes(b"incomplete")
+
+    store = make_result_store(tmp_path)
+    asyncio.run(store.startup())
+    try:
+        assert not partial.exists()
+    finally:
+        asyncio.run(store.shutdown())
+
+
+# ---------------------------------------------------------------------------
+# Tests: ArchiveTicketService.prepare
+# ---------------------------------------------------------------------------
+
+
+def test_prepare_returns_pending_response_for_ready_source_ticket(tmp_path):
+    store = make_result_store(tmp_path)
+    service = ArchiveTicketService()
+
+    asyncio.run(store.startup())
+    try:
+        source = make_ready_source_ticket(store)
+
+        with patch("api_swedeb.api.services.archive_ticket_service.ConfigValue.resolve", return_value=2):
+            response = service.prepare(
+                source_ticket_id=source.ticket_id,
+                archive_format=BulkArchiveFormat.jsonl_gz,
+                result_store=store,
+            )
+
+        assert response.status == "pending"
+        assert response.source_ticket_id == source.ticket_id
+        assert response.archive_format == "jsonl_gz"
+        assert response.retry_after == 2
+
+        archive_ticket = store.require_ticket(response.archive_ticket_id)
+        assert archive_ticket.status == TicketStatus.PENDING
+        assert archive_ticket.source_ticket_id == source.ticket_id
+        assert archive_ticket.archive_format == "jsonl_gz"
+    finally:
+        asyncio.run(store.shutdown())
+
+
+def test_prepare_raises_for_missing_source_ticket(tmp_path):
+    store = make_result_store(tmp_path)
+    service = ArchiveTicketService()
+
+    asyncio.run(store.startup())
+    try:
+        with pytest.raises(ResultStoreNotFound):
+            service.prepare(
+                source_ticket_id="nonexistent",
+                archive_format=BulkArchiveFormat.jsonl_gz,
+                result_store=store,
+            )
+    finally:
+        asyncio.run(store.shutdown())
+
+
+def test_prepare_raises_for_pending_source_ticket(tmp_path):
+    store = make_result_store(tmp_path)
+    service = ArchiveTicketService()
+
+    asyncio.run(store.startup())
+    try:
+        pending = store.create_ticket(query_meta={"search": ["demokrati"]})
+
+        with pytest.raises(ValueError, match="not ready yet"):
+            service.prepare(
+                source_ticket_id=pending.ticket_id,
+                archive_format=BulkArchiveFormat.jsonl_gz,
+                result_store=store,
+            )
+    finally:
+        asyncio.run(store.shutdown())
+
+
+def test_prepare_raises_for_error_source_ticket(tmp_path):
+    store = make_result_store(tmp_path)
+    service = ArchiveTicketService()
+
+    asyncio.run(store.startup())
+    try:
+        ticket = store.create_ticket()
+        store.store_error(ticket.ticket_id, message="corpus failure")
+
+        with pytest.raises(ValueError, match="error state"):
+            service.prepare(
+                source_ticket_id=ticket.ticket_id,
+                archive_format=BulkArchiveFormat.jsonl_gz,
+                result_store=store,
+            )
+    finally:
+        asyncio.run(store.shutdown())
+
+
+def test_prepare_raises_for_ready_ticket_with_no_speech_ids(tmp_path):
+    store = make_result_store(tmp_path)
+    service = ArchiveTicketService()
+
+    asyncio.run(store.startup())
+    try:
+        # Store a ticket READY but without speech_ids
+        ticket = store.create_ticket()
+        frame = pd.DataFrame([{"node_word": "x"}])
+        store.store_ready(ticket.ticket_id, df=frame, speech_ids=None, manifest_meta={})
+
+        with pytest.raises(ValueError, match="no speech IDs"):
+            service.prepare(
+                source_ticket_id=ticket.ticket_id,
+                archive_format=BulkArchiveFormat.jsonl_gz,
+                result_store=store,
+            )
+    finally:
+        asyncio.run(store.shutdown())
+
+
+# ---------------------------------------------------------------------------
+# Tests: ArchiveTicketService.execute_archive_task
+# ---------------------------------------------------------------------------
+
+
+def test_execute_archive_task_jsonl_gz_marks_ticket_ready(tmp_path):
+    store = make_result_store(tmp_path)
+    service = ArchiveTicketService()
+    search_service = make_mock_search_service()
+
+    asyncio.run(store.startup())
+    try:
+        source = make_ready_source_ticket(store)
+        archive_ticket = store.create_ticket(source_ticket_id=source.ticket_id, archive_format="jsonl_gz")
+
+        service.execute_archive_task(
+            archive_ticket_id=archive_ticket.ticket_id,
+            result_store=store,
+            search_service=search_service,
+        )
+
+        ready = store.require_ticket(archive_ticket.ticket_id)
+        assert ready.status == TicketStatus.READY
+        assert ready.artifact_path is not None
+        assert ready.artifact_path.exists()
+        assert ready.total_hits == len(SAMPLE_SPEECH_IDS)
+    finally:
+        asyncio.run(store.shutdown())
+
+
+def test_execute_archive_task_jsonl_gz_output_is_valid(tmp_path):
+    store = make_result_store(tmp_path)
+    service = ArchiveTicketService()
+    search_service = make_mock_search_service()
+
+    asyncio.run(store.startup())
+    try:
+        source = make_ready_source_ticket(store)
+        archive_ticket = store.create_ticket(source_ticket_id=source.ticket_id, archive_format="jsonl_gz")
+
+        service.execute_archive_task(
+            archive_ticket_id=archive_ticket.ticket_id,
+            result_store=store,
+            search_service=search_service,
+        )
+
+        ready = store.require_ticket(archive_ticket.ticket_id)
+        records = []
+        with gzip.open(str(ready.artifact_path), "rb") as gz:
+            for line in gz:
+                records.append(json.loads(line))
+
+        assert [r["speech_id"] for r in records] == [sid for sid, _ in SAMPLE_SPEECHES_TEXT]
+        assert [r["text"] for r in records] == [text for _, text in SAMPLE_SPEECHES_TEXT]
+    finally:
+        asyncio.run(store.shutdown())
+
+
+def test_execute_archive_task_zip_marks_ticket_ready(tmp_path):
+    store = make_result_store(tmp_path)
+    service = ArchiveTicketService()
+    search_service = make_mock_search_service()
+
+    asyncio.run(store.startup())
+    try:
+        source = make_ready_source_ticket(store)
+        archive_ticket = store.create_ticket(source_ticket_id=source.ticket_id, archive_format="zip")
+
+        service.execute_archive_task(
+            archive_ticket_id=archive_ticket.ticket_id,
+            result_store=store,
+            search_service=search_service,
+        )
+
+        ready = store.require_ticket(archive_ticket.ticket_id)
+        assert ready.status == TicketStatus.READY
+        assert ready.artifact_path is not None
+        assert zipfile.is_zipfile(str(ready.artifact_path))
+    finally:
+        asyncio.run(store.shutdown())
+
+
+def test_execute_archive_task_marks_ticket_failed_on_error(tmp_path):
+    store = make_result_store(tmp_path)
+    service = ArchiveTicketService()
+    search_service = MagicMock()
+    search_service.get_speeches_text_batch.side_effect = RuntimeError("corpus failure")
+
+    asyncio.run(store.startup())
+    try:
+        source = make_ready_source_ticket(store)
+        archive_ticket = store.create_ticket(source_ticket_id=source.ticket_id, archive_format="jsonl_gz")
+
+        service.execute_archive_task(
+            archive_ticket_id=archive_ticket.ticket_id,
+            result_store=store,
+            search_service=search_service,
+        )
+
+        failed = store.require_ticket(archive_ticket.ticket_id)
+        assert failed.status == TicketStatus.ERROR
+        assert failed.error is not None
+    finally:
+        asyncio.run(store.shutdown())
+
+
+def test_execute_archive_task_cleans_up_partial_file_on_error(tmp_path):
+    store = make_result_store(tmp_path)
+    service = ArchiveTicketService()
+    search_service = MagicMock()
+    search_service.get_speeches_text_batch.side_effect = RuntimeError("write failure")
+
+    asyncio.run(store.startup())
+    try:
+        source = make_ready_source_ticket(store)
+        archive_ticket = store.create_ticket(source_ticket_id=source.ticket_id, archive_format="jsonl_gz")
+
+        service.execute_archive_task(
+            archive_ticket_id=archive_ticket.ticket_id,
+            result_store=store,
+            search_service=search_service,
+        )
+
+        dest_path = store.archive_artifact_path(archive_ticket.ticket_id, "jsonl_gz")
+        partial_path = Path(str(dest_path) + ".partial")
+        assert not partial_path.exists()
+    finally:
+        asyncio.run(store.shutdown())
+
+
+# ---------------------------------------------------------------------------
+# Tests: ArchiveTicketService.get_status
+# ---------------------------------------------------------------------------
+
+
+def test_get_status_returns_pending_for_pending_ticket(tmp_path):
+    store = make_result_store(tmp_path)
+    service = ArchiveTicketService()
+
+    asyncio.run(store.startup())
+    try:
+        source = make_ready_source_ticket(store)
+        archive_ticket = store.create_ticket(source_ticket_id=source.ticket_id, archive_format="jsonl_gz")
+
+        status = service.get_status(archive_ticket.ticket_id, store)
+        assert status.status == "pending"
+        assert status.archive_ticket_id == archive_ticket.ticket_id
+        assert status.source_ticket_id == source.ticket_id
+        assert status.archive_format == "jsonl_gz"
+        assert status.speech_count is None
+    finally:
+        asyncio.run(store.shutdown())
+
+
+def test_get_status_returns_ready_after_execute(tmp_path):
+    store = make_result_store(tmp_path)
+    service = ArchiveTicketService()
+    search_service = make_mock_search_service()
+
+    asyncio.run(store.startup())
+    try:
+        source = make_ready_source_ticket(store)
+        archive_ticket = store.create_ticket(source_ticket_id=source.ticket_id, archive_format="jsonl_gz")
+        service.execute_archive_task(
+            archive_ticket_id=archive_ticket.ticket_id,
+            result_store=store,
+            search_service=search_service,
+        )
+
+        status = service.get_status(archive_ticket.ticket_id, store)
+        assert status.status == "ready"
+        assert status.speech_count == len(SAMPLE_SPEECH_IDS)
+    finally:
+        asyncio.run(store.shutdown())
+
+
+def test_get_status_returns_error_after_failed_execute(tmp_path):
+    store = make_result_store(tmp_path)
+    service = ArchiveTicketService()
+    search_service = MagicMock()
+    search_service.get_speeches_text_batch.side_effect = RuntimeError("failure")
+
+    asyncio.run(store.startup())
+    try:
+        source = make_ready_source_ticket(store)
+        archive_ticket = store.create_ticket(source_ticket_id=source.ticket_id, archive_format="jsonl_gz")
+        service.execute_archive_task(
+            archive_ticket_id=archive_ticket.ticket_id,
+            result_store=store,
+            search_service=search_service,
+        )
+
+        status = service.get_status(archive_ticket.ticket_id, store)
+        assert status.status == "error"
+        assert status.error is not None
+    finally:
+        asyncio.run(store.shutdown())
+
+
+def test_get_status_raises_for_unknown_ticket(tmp_path):
+    store = make_result_store(tmp_path)
+    service = ArchiveTicketService()
+
+    asyncio.run(store.startup())
+    try:
+        with pytest.raises(ResultStoreNotFound):
+            service.get_status("nonexistent", store)
+    finally:
+        asyncio.run(store.shutdown())

--- a/tests/api_swedeb/api/services/test_archive_ticket_service.py
+++ b/tests/api_swedeb/api/services/test_archive_ticket_service.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import asyncio
 import csv
 import gzip
-import io
 import json
 import zipfile
 from dataclasses import replace

--- a/tests/api_swedeb/api/services/test_kwic_ticket_service.py
+++ b/tests/api_swedeb/api/services/test_kwic_ticket_service.py
@@ -53,7 +53,6 @@ def test_execute_ticket_stores_mapped_artifact_and_manifest(tmp_path):
     )
     request = KWICQueryRequest(search="demokrati")
 
-
     asyncio.run(store.startup())
     try:
         ticket = store.create_ticket(query_meta={"search": "demokrati"})
@@ -91,7 +90,6 @@ def test_get_page_result_sorts_with_ticket_row_id_tiebreaker(tmp_path):
         max_page_size=200,
     )
     service = KWICTicketService()
-
 
     asyncio.run(store.startup())
     try:
@@ -146,7 +144,6 @@ def test_get_page_result_rejects_out_of_range_page(tmp_path):
         max_page_size=200,
     )
     service = KWICTicketService()
-
 
     asyncio.run(store.startup())
     try:
@@ -249,7 +246,6 @@ def test_get_status_uses_celery_success_result(tmp_path):
     )
     celery_result = MagicMock(state="SUCCESS", result={"row_count": 12}, info=None)
 
-
     asyncio.run(result_store.startup())
     try:
         ticket = result_store.create_ticket(query_meta={"search": "demokrati"})
@@ -278,7 +274,6 @@ def test_get_status_celery_success_syncs_ready_state_and_releases_pending_capaci
         max_page_size=200,
     )
     service = KWICTicketService()
-
 
     asyncio.run(store.startup())
     try:
@@ -315,7 +310,6 @@ def test_get_status_uses_celery_failure_result_and_syncs_error_state(tmp_path):
     )
     celery_result = MagicMock(state="FAILURE", result=None, info=RuntimeError("boom"))
 
-
     asyncio.run(result_store.startup())
     try:
         ticket = result_store.create_ticket(query_meta={"search": "demokrati"})
@@ -344,7 +338,6 @@ def test_get_status_celery_raises_for_unknown_ticket(tmp_path):
     )
     service = KWICTicketService()
 
-
     asyncio.run(store.startup())
     try:
         celery_result = MagicMock(state="PENDING", result=None, info=None)
@@ -370,7 +363,6 @@ def test_get_page_result_reads_celery_artifact(tmp_path):
     )
 
     celery_result = MagicMock(state="SUCCESS", result={"row_count": 2}, info=None)
-
 
     asyncio.run(result_store.startup())
     try:

--- a/tests/api_swedeb/api/services/test_kwic_ticket_service.py
+++ b/tests/api_swedeb/api/services/test_kwic_ticket_service.py
@@ -1,3 +1,4 @@
+import asyncio
 from dataclasses import replace
 from datetime import UTC, datetime, timedelta
 from unittest.mock import MagicMock, patch
@@ -52,7 +53,6 @@ def test_execute_ticket_stores_mapped_artifact_and_manifest(tmp_path):
     )
     request = KWICQueryRequest(search="demokrati")
 
-    import asyncio
 
     asyncio.run(store.startup())
     try:
@@ -92,7 +92,6 @@ def test_get_page_result_sorts_with_ticket_row_id_tiebreaker(tmp_path):
     )
     service = KWICTicketService()
 
-    import asyncio
 
     asyncio.run(store.startup())
     try:
@@ -148,7 +147,6 @@ def test_get_page_result_rejects_out_of_range_page(tmp_path):
     )
     service = KWICTicketService()
 
-    import asyncio
 
     asyncio.run(store.startup())
     try:
@@ -251,7 +249,6 @@ def test_get_status_uses_celery_success_result(tmp_path):
     )
     celery_result = MagicMock(state="SUCCESS", result={"row_count": 12}, info=None)
 
-    import asyncio
 
     asyncio.run(result_store.startup())
     try:
@@ -282,7 +279,6 @@ def test_get_status_celery_success_syncs_ready_state_and_releases_pending_capaci
     )
     service = KWICTicketService()
 
-    import asyncio
 
     asyncio.run(store.startup())
     try:
@@ -319,7 +315,6 @@ def test_get_status_uses_celery_failure_result_and_syncs_error_state(tmp_path):
     )
     celery_result = MagicMock(state="FAILURE", result=None, info=RuntimeError("boom"))
 
-    import asyncio
 
     asyncio.run(result_store.startup())
     try:
@@ -349,7 +344,6 @@ def test_get_status_celery_raises_for_unknown_ticket(tmp_path):
     )
     service = KWICTicketService()
 
-    import asyncio
 
     asyncio.run(store.startup())
     try:
@@ -377,7 +371,6 @@ def test_get_page_result_reads_celery_artifact(tmp_path):
 
     celery_result = MagicMock(state="SUCCESS", result={"row_count": 2}, info=None)
 
-    import asyncio
 
     asyncio.run(result_store.startup())
     try:
@@ -428,7 +421,7 @@ def test_get_page_result_reads_celery_artifact(tmp_path):
 def test_speech_ids_returns_empty_list_when_column_missing():
     service = KWICTicketService()
 
-    assert service._speech_ids(pd.DataFrame([{"node_word": "demokrati"}])) == []
+    assert not service._speech_ids(pd.DataFrame([{"node_word": "demokrati"}]))
 
 
 # ---------------------------------------------------------------------------
@@ -437,7 +430,6 @@ def test_speech_ids_returns_empty_list_when_column_missing():
 
 
 def test_get_page_result_advances_ticket_expiry(tmp_path):
-    import asyncio
 
     store = ResultStore(
         root_dir=tmp_path,
@@ -492,7 +484,6 @@ def test_get_page_result_advances_ticket_expiry(tmp_path):
 
 
 def test_get_status_does_not_advance_ticket_expiry(tmp_path):
-    import asyncio
 
     store = ResultStore(
         root_dir=tmp_path,

--- a/tests/api_swedeb/api/services/test_speeches_ticket_service.py
+++ b/tests/api_swedeb/api/services/test_speeches_ticket_service.py
@@ -72,7 +72,6 @@ def make_result_store(tmp_path, *, ticket_state_store=None):
 
 
 def make_mock_search_service(speeches=None):
-    from unittest.mock import MagicMock
 
     service = MagicMock()
     frame = pd.DataFrame(speeches if speeches is not None else SAMPLE_SPEECHES)
@@ -227,7 +226,7 @@ def test_get_celery_page_result_uses_result_store_load_artifact():
     assert [speech.speech_id for speech in result.speech_list] == ["i-1", "i-2"]
 
 
-def test_get_page_result_touches_ticket(tmp_path):
+def test_get_page_result_touches_ticket():
     """get_page_result() must call touch_ticket so that expires_at advances on every page access."""
     result_store = MagicMock()
     service = SpeechesTicketService()

--- a/tests/api_swedeb/api/test_archive_endpoints.py
+++ b/tests/api_swedeb/api/test_archive_endpoints.py
@@ -85,9 +85,9 @@ def make_ready_archive_ticket(store: ResultStore, source_ticket_id: str, search_
 # ---------------------------------------------------------------------------
 
 
-@pytest.fixture()
-def archive_client(tmp_path) -> Generator[tuple[TestClient, ResultStore], None, None]:
-    """Yields (client, store) with a real in-memory ResultStore and mocked services."""
+@pytest.fixture(name="archive_client")
+def _archive_client(tmp_path) -> Generator[tuple[TestClient, ResultStore, MagicMock], None, None]:
+    """Yields (client, store, search_service) with a real in-memory ResultStore and mocked services."""
     store = make_result_store(tmp_path)
     asyncio.run(store.startup())
 
@@ -98,7 +98,7 @@ def archive_client(tmp_path) -> Generator[tuple[TestClient, ResultStore], None, 
 
     app.dependency_overrides[get_result_store] = lambda: store
     app.dependency_overrides[get_search_service] = lambda: search_service
-    app.dependency_overrides[get_archive_ticket_service] = lambda: ArchiveTicketService()
+    app.dependency_overrides[get_archive_ticket_service] = ArchiveTicketService
 
     try:
         with TestClient(app, raise_server_exceptions=True) as client:
@@ -112,7 +112,7 @@ def archive_client(tmp_path) -> Generator[tuple[TestClient, ResultStore], None, 
 # ---------------------------------------------------------------------------
 
 
-def test_prepare_wt_archive_returns_202_with_archive_ticket_id(archive_client, tmp_path):
+def test_prepare_wt_archive_returns_202_with_archive_ticket_id(archive_client):
     client, store, _ = archive_client
     source = make_ready_source_ticket(store)
 
@@ -130,7 +130,7 @@ def test_prepare_wt_archive_returns_202_with_archive_ticket_id(archive_client, t
 
 
 def test_prepare_wt_archive_returns_404_for_missing_source_ticket(archive_client):
-    client, store, _ = archive_client
+    client, _, _ = archive_client
 
     r = client.post("/v1/tools/word_trend_speeches/archive/nonexistent")
     assert r.status_code == 404
@@ -155,7 +155,7 @@ def test_prepare_speeches_archive_returns_202(archive_client):
 
 
 def test_prepare_speeches_archive_returns_404_for_missing_source_ticket(archive_client):
-    client, store, _ = archive_client
+    client, _, _ = archive_client
 
     r = client.post("/v1/tools/speeches/archive/nonexistent")
     assert r.status_code == 404

--- a/tests/api_swedeb/api/test_archive_endpoints.py
+++ b/tests/api_swedeb/api/test_archive_endpoints.py
@@ -1,0 +1,265 @@
+"""Endpoint tests for the bulk archive routes (checklist item 11).
+
+Strategy: build a FastAPI TestClient with dependency overrides for every
+injected service so no real corpus or Redis is needed.  The ResultStore is
+real (in-memory, tmp_path) so state transitions are exercised end-to-end.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import gzip
+import json
+from pathlib import Path
+from typing import Generator
+from unittest.mock import MagicMock
+
+import pandas as pd
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from api_swedeb.api.dependencies import (
+    get_archive_ticket_service,
+    get_result_store,
+    get_search_service,
+)
+from api_swedeb.api.services.archive_ticket_service import ArchiveTicketService
+from api_swedeb.api.services.result_store import ResultStore, TicketMeta
+from api_swedeb.api.v1.endpoints import tool_router
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+SAMPLE_SPEECH_IDS = ["i-1", "i-2"]
+SAMPLE_SPEECHES = [("i-1", "text one"), ("i-2", "text two")]
+
+
+def make_result_store(tmp_path: Path) -> ResultStore:
+    return ResultStore(
+        root_dir=tmp_path,
+        result_ttl_seconds=600,
+        cleanup_interval_seconds=0,
+        max_artifact_bytes=10_000_000,
+        max_pending_jobs=10,
+        max_page_size=500,
+    )
+
+
+def make_mock_search_service() -> MagicMock:
+    svc = MagicMock()
+    svc.get_speeches_text_batch.return_value = SAMPLE_SPEECHES
+    svc.get_speaker_names.return_value = {"i-1": "Alice", "i-2": "Bob"}
+    return svc
+
+
+def make_ready_source_ticket(store: ResultStore) -> TicketMeta:
+    ticket = store.create_ticket(query_meta={"search": ["demokrati"]})
+    frame = pd.DataFrame([{"speech_id": sid, "node_word": "demokrati"} for sid in SAMPLE_SPEECH_IDS])
+    store.store_ready(
+        ticket.ticket_id,
+        df=frame,
+        speech_ids=SAMPLE_SPEECH_IDS,
+        manifest_meta={"search": ["demokrati"], "total_hits": 2},
+    )
+    return store.require_ticket(ticket.ticket_id)
+
+
+def make_ready_archive_ticket(store: ResultStore, source_ticket_id: str, search_service: MagicMock) -> TicketMeta:
+    archive_ticket = store.create_ticket(
+        source_ticket_id=source_ticket_id,
+        archive_format="jsonl_gz",
+    )
+    svc = ArchiveTicketService()
+    svc.execute_archive_task(
+        archive_ticket_id=archive_ticket.ticket_id,
+        result_store=store,
+        search_service=search_service,
+    )
+    return store.require_ticket(archive_ticket.ticket_id)
+
+
+# ---------------------------------------------------------------------------
+# Fixture: TestClient with dependency overrides
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def archive_client(tmp_path) -> Generator[tuple[TestClient, ResultStore], None, None]:
+    """Yields (client, store) with a real in-memory ResultStore and mocked services."""
+    store = make_result_store(tmp_path)
+    asyncio.run(store.startup())
+
+    search_service = make_mock_search_service()
+
+    app = FastAPI()
+    app.include_router(tool_router.router)
+
+    app.dependency_overrides[get_result_store] = lambda: store
+    app.dependency_overrides[get_search_service] = lambda: search_service
+    app.dependency_overrides[get_archive_ticket_service] = lambda: ArchiveTicketService()
+
+    try:
+        with TestClient(app, raise_server_exceptions=True) as client:
+            yield client, store, search_service
+    finally:
+        asyncio.run(store.shutdown())
+
+
+# ---------------------------------------------------------------------------
+# Tests: POST .../archive/{ticket_id} — prepare
+# ---------------------------------------------------------------------------
+
+
+def test_prepare_wt_archive_returns_202_with_archive_ticket_id(archive_client, tmp_path):
+    client, store, _ = archive_client
+    source = make_ready_source_ticket(store)
+
+    r = client.post(
+        f"/v1/tools/word_trend_speeches/archive/{source.ticket_id}",
+        params={"archive_format": "jsonl_gz"},
+    )
+
+    assert r.status_code == 202
+    body = r.json()
+    assert "archive_ticket_id" in body
+    assert body["status"] == "pending"
+    assert body["source_ticket_id"] == source.ticket_id
+    assert body["archive_format"] == "jsonl_gz"
+
+
+def test_prepare_wt_archive_returns_404_for_missing_source_ticket(archive_client):
+    client, store, _ = archive_client
+
+    r = client.post("/v1/tools/word_trend_speeches/archive/nonexistent")
+    assert r.status_code == 404
+
+
+def test_prepare_wt_archive_returns_409_for_pending_source_ticket(archive_client):
+    client, store, _ = archive_client
+    pending = store.create_ticket(query_meta={"search": ["test"]})
+
+    r = client.post(f"/v1/tools/word_trend_speeches/archive/{pending.ticket_id}")
+    assert r.status_code == 409
+
+
+def test_prepare_speeches_archive_returns_202(archive_client):
+    client, store, _ = archive_client
+    source = make_ready_source_ticket(store)
+
+    r = client.post(f"/v1/tools/speeches/archive/{source.ticket_id}")
+
+    assert r.status_code == 202
+    assert r.json()["source_ticket_id"] == source.ticket_id
+
+
+def test_prepare_speeches_archive_returns_404_for_missing_source_ticket(archive_client):
+    client, store, _ = archive_client
+
+    r = client.post("/v1/tools/speeches/archive/nonexistent")
+    assert r.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Tests: GET .../archive/status/{archive_ticket_id}
+# ---------------------------------------------------------------------------
+
+
+def test_get_wt_archive_status_returns_pending(archive_client):
+    client, store, _ = archive_client
+    source = make_ready_source_ticket(store)
+
+    prepare_r = client.post(f"/v1/tools/word_trend_speeches/archive/{source.ticket_id}")
+    archive_ticket_id = prepare_r.json()["archive_ticket_id"]
+
+    status_r = client.get(f"/v1/tools/word_trend_speeches/archive/status/{archive_ticket_id}")
+    assert status_r.status_code == 200
+    body = status_r.json()
+    assert body["archive_ticket_id"] == archive_ticket_id
+    assert body["status"] in {"pending", "ready"}  # background task may have run inline
+
+
+def test_get_speeches_archive_status_returns_ready_for_ready_ticket(archive_client):
+    client, store, search_service = archive_client
+    source = make_ready_source_ticket(store)
+    ready_archive = make_ready_archive_ticket(store, source.ticket_id, search_service)
+
+    status_r = client.get(f"/v1/tools/speeches/archive/status/{ready_archive.ticket_id}")
+    assert status_r.status_code == 200
+    assert status_r.json()["status"] == "ready"
+
+
+def test_get_wt_archive_status_returns_404_for_unknown(archive_client):
+    client, *_ = archive_client
+
+    r = client.get("/v1/tools/word_trend_speeches/archive/status/nonexistent")
+    assert r.status_code == 404
+
+
+def test_get_speeches_archive_status_returns_404_for_unknown(archive_client):
+    client, *_ = archive_client
+
+    r = client.get("/v1/tools/speeches/archive/status/nonexistent")
+    assert r.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Tests: GET .../archive/download/{archive_ticket_id}
+# ---------------------------------------------------------------------------
+
+
+def test_download_wt_archive_returns_file_for_ready_ticket(archive_client):
+    client, store, search_service = archive_client
+    source = make_ready_source_ticket(store)
+    ready_archive = make_ready_archive_ticket(store, source.ticket_id, search_service)
+
+    r = client.get(f"/v1/tools/word_trend_speeches/archive/download/{ready_archive.ticket_id}")
+    assert r.status_code == 200
+    assert r.headers["content-type"].startswith("application/gzip")
+    # Verify it is valid jsonl.gz
+    records = [json.loads(line) for line in gzip.decompress(r.content).splitlines()]
+    assert len(records) == len(SAMPLE_SPEECH_IDS)
+
+
+def test_download_speeches_archive_returns_file_for_ready_ticket(archive_client):
+    client, store, search_service = archive_client
+    source = make_ready_source_ticket(store)
+    ready_archive = make_ready_archive_ticket(store, source.ticket_id, search_service)
+
+    r = client.get(f"/v1/tools/speeches/archive/download/{ready_archive.ticket_id}")
+    assert r.status_code == 200
+    assert r.headers["content-type"].startswith("application/gzip")
+
+
+def test_download_wt_archive_returns_404_for_missing_ticket(archive_client):
+    client, *_ = archive_client
+
+    r = client.get("/v1/tools/word_trend_speeches/archive/download/nonexistent")
+    assert r.status_code == 404
+
+
+def test_download_speeches_archive_returns_404_for_missing_ticket(archive_client):
+    client, *_ = archive_client
+
+    r = client.get("/v1/tools/speeches/archive/download/nonexistent")
+    assert r.status_code == 404
+
+
+def test_download_wt_archive_returns_409_for_pending_ticket(archive_client):
+    client, store, _ = archive_client
+    source = make_ready_source_ticket(store)
+    # Create an archive ticket but don't execute it so it stays PENDING
+    pending = store.create_ticket(source_ticket_id=source.ticket_id, archive_format="jsonl_gz")
+
+    r = client.get(f"/v1/tools/word_trend_speeches/archive/download/{pending.ticket_id}")
+    assert r.status_code == 409
+
+
+def test_download_speeches_archive_returns_409_for_pending_ticket(archive_client):
+    client, store, _ = archive_client
+    source = make_ready_source_ticket(store)
+    pending = store.create_ticket(source_ticket_id=source.ticket_id, archive_format="jsonl_gz")
+
+    r = client.get(f"/v1/tools/speeches/archive/download/{pending.ticket_id}")
+    assert r.status_code == 409


### PR DESCRIPTION
Introduce a ticket-based system for bulk speech archive generation, allowing users to create archives in various formats. This includes enhancements to the TicketMeta and ResultStore, the implementation of an ArchiveTicketService, and the addition of multiple endpoints for managing archive tasks. Update documentation to reflect new operational details regarding archive storage and management.