### PR TITLE
Add asynchronous KWIC archive export endpoint

### DIFF
--- a/api_swedeb/api/container.py
+++ b/api_swedeb/api/container.py
@@ -41,6 +41,7 @@ from fastapi import Request
 from api_swedeb.api.services.archive_ticket_service import ArchiveTicketService
 from api_swedeb.api.services.corpus_loader import CorpusLoader
 from api_swedeb.api.services.download_service import DownloadService
+from api_swedeb.api.services.kwic_archive_service import KWICArchiveService
 from api_swedeb.api.services.kwic_service import KWICService
 from api_swedeb.api.services.kwic_ticket_service import KWICTicketService
 from api_swedeb.api.services.metadata_service import MetadataService
@@ -63,6 +64,7 @@ class AppContainer:
     speeches_ticket_service: SpeechesTicketService
     kwic_service: KWICService
     kwic_ticket_service: KWICTicketService
+    kwic_archive_service: KWICArchiveService
     word_trend_speeches_ticket_service: WordTrendSpeechesTicketService
     download_service: DownloadService
     archive_ticket_service: ArchiveTicketService
@@ -80,6 +82,7 @@ class AppContainer:
             speeches_ticket_service=SpeechesTicketService(),
             kwic_service=KWICService(corpus_loader),
             kwic_ticket_service=KWICTicketService(),
+            kwic_archive_service=KWICArchiveService(),
             word_trend_speeches_ticket_service=WordTrendSpeechesTicketService(),
             download_service=DownloadService(),
             archive_ticket_service=ArchiveTicketService(),

--- a/api_swedeb/api/dependencies.py
+++ b/api_swedeb/api/dependencies.py
@@ -9,6 +9,7 @@ from api_swedeb.api.container import AppContainer, get_container
 from api_swedeb.api.services.archive_ticket_service import ArchiveTicketService
 from api_swedeb.api.services.corpus_loader import CorpusLoader
 from api_swedeb.api.services.download_service import DownloadService
+from api_swedeb.api.services.kwic_archive_service import KWICArchiveService
 from api_swedeb.api.services.kwic_service import KWICService
 from api_swedeb.api.services.kwic_ticket_service import KWICTicketService
 from api_swedeb.api.services.metadata_service import MetadataService
@@ -53,6 +54,11 @@ def get_speeches_ticket_service(container: AppContainer = Depends(get_container)
 
 def get_kwic_ticket_service(container: AppContainer = Depends(get_container)) -> KWICTicketService:
     return container.kwic_ticket_service
+
+
+def get_kwic_archive_service(container: AppContainer = Depends(get_container)) -> KWICArchiveService:
+    """Get the app-scoped KWICArchiveService instance."""
+    return container.kwic_archive_service
 
 
 def get_word_trend_speeches_ticket_service(

--- a/api_swedeb/api/services/archive_ticket_service.py
+++ b/api_swedeb/api/services/archive_ticket_service.py
@@ -6,7 +6,7 @@ import os
 from datetime import UTC, datetime
 from functools import lru_cache
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from loguru import logger
 
@@ -21,10 +21,17 @@ from api_swedeb.api.services.search_service import SearchService
 from api_swedeb.api.services.ticketed_download_service import TicketedDownloadService
 from api_swedeb.core.configuration import ConfigValue
 from api_swedeb.schemas.bulk_archive_schema import (
+    ARCHIVE_MEDIA_TYPES,
+    ARCHIVE_SUFFIXES,
     ArchivePrepareResponse,
     ArchiveTicketStatus,
     BulkArchiveFormat,
 )
+
+if TYPE_CHECKING:
+    from fastapi.responses import FileResponse
+
+
 
 # ---------------------------------------------------------------------------
 # Per-worker singleton helpers (Celery workers only)
@@ -180,6 +187,50 @@ class ArchiveTicketService:
         except Exception as exc:  # pylint: disable=broad-except
             logger.exception(f"Error executing archive ticket {archive_ticket_id}: {exc}")
             result_store.store_error(archive_ticket_id, message="Failed to generate archive")
+
+    def build_file_response(
+        self,
+        *,
+        archive_ticket_id: str,
+        filename_stem: str,
+        result_store: ResultStore,
+    ) -> FileResponse:
+        """Validate a ready archive ticket and return a FileResponse for its artifact.
+
+        Raises HTTPException for all error states (404, 409, 410).
+        Touches the ticket to defer expiry before streaming.
+        """
+        from fastapi import HTTPException  # pylint: disable=import-outside-toplevel
+        from fastapi.responses import FileResponse  # pylint: disable=import-outside-toplevel
+
+        try:
+            ticket: TicketMeta = result_store.require_ticket(archive_ticket_id)
+        except ResultStoreNotFound as e:
+            raise HTTPException(status_code=404, detail="Archive ticket not found or expired") from e
+
+        if ticket.status == TicketStatus.ERROR:
+            raise HTTPException(status_code=409, detail=ticket.error or "Archive preparation failed")
+        if ticket.status != TicketStatus.READY:
+            raise HTTPException(status_code=409, detail="Archive is not ready yet")
+        if ticket.artifact_path is None or not ticket.artifact_path.exists():
+            raise HTTPException(status_code=410, detail="Archive file no longer available")
+
+        archive_format_str: str = ticket.archive_format or BulkArchiveFormat.jsonl_gz.value
+        try:
+            archive_format = BulkArchiveFormat(archive_format_str)
+        except ValueError:
+            archive_format = BulkArchiveFormat.jsonl_gz
+
+        media_type: str = ARCHIVE_MEDIA_TYPES.get(archive_format, "application/octet-stream")
+        suffix: str = ARCHIVE_SUFFIXES.get(archive_format, f".{archive_format_str}")
+        filename: str = f"{filename_stem}_{archive_ticket_id}{suffix}"
+
+        try:
+            result_store.touch_ticket(archive_ticket_id)
+        except ResultStoreNotFound as e:
+            raise HTTPException(status_code=404, detail="Archive ticket not found or expired") from e
+
+        return FileResponse(path=str(ticket.artifact_path), media_type=media_type, filename=filename)
 
     def get_status(self, archive_ticket_id: str, result_store: ResultStore) -> ArchiveTicketStatus:
         ticket: TicketMeta = result_store.require_ticket(archive_ticket_id)

--- a/api_swedeb/api/services/archive_ticket_service.py
+++ b/api_swedeb/api/services/archive_ticket_service.py
@@ -32,7 +32,6 @@ if TYPE_CHECKING:
     from fastapi.responses import FileResponse
 
 
-
 # ---------------------------------------------------------------------------
 # Per-worker singleton helpers (Celery workers only)
 # ---------------------------------------------------------------------------

--- a/api_swedeb/api/services/kwic_archive_service.py
+++ b/api_swedeb/api/services/kwic_archive_service.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import csv
 import gzip
 import io
 import json
@@ -11,6 +10,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
+import pandas as pd
 from loguru import logger
 
 from api_swedeb.api.services.result_store import (
@@ -22,8 +22,6 @@ from api_swedeb.api.services.result_store import (
 )
 from api_swedeb.core.configuration import ConfigValue
 from api_swedeb.schemas.bulk_archive_schema import (
-    ARCHIVE_MEDIA_TYPES,
-    ARCHIVE_SUFFIXES,
     ArchivePrepareResponse,
     BulkArchiveFormat,
 )
@@ -119,8 +117,6 @@ class KWICArchiveService:
 
             archive_format = BulkArchiveFormat(archive_format_str)
 
-            import pandas as pd  # pylint: disable=import-outside-toplevel
-
             data: pd.DataFrame = result_store.load_artifact(source_ticket_id)
             data = data.drop(columns=[_TICKET_ROW_ID], errors="ignore")
 
@@ -160,7 +156,6 @@ class KWICArchiveService:
         archive_format: BulkArchiveFormat,
         dest_path: Path,
     ) -> None:
-        import pandas as pd  # pylint: disable=import-outside-toplevel
 
         partial = Path(str(dest_path) + ".partial")
         partial.parent.mkdir(parents=True, exist_ok=True)
@@ -185,7 +180,9 @@ class KWICArchiveService:
     def _write_jsonl_gz(self, data: "pd.DataFrame", dest: Path) -> None:
         with gzip.open(str(dest), "wb", compresslevel=1) as gz:
             for record in data.to_dict(orient="records"):
-                cleaned = {k: (None if isinstance(v, float) and v != v else v) for k, v in record.items()}
+                import math  # pylint: disable=import-outside-toplevel
+
+                cleaned = {k: (None if isinstance(v, float) and math.isnan(v) else v) for k, v in record.items()}
                 line = (json.dumps(cleaned, ensure_ascii=False, default=str) + "\n").encode("utf-8")
                 gz.write(line)
 
@@ -197,7 +194,6 @@ class KWICArchiveService:
         dest.write_bytes(buf.getvalue())
 
     def _write_xlsx(self, data: "pd.DataFrame", dest: Path) -> None:
-        import openpyxl  # pylint: disable=import-outside-toplevel  # noqa: F401
 
         # pandas/openpyxl validates the file extension, so we must use .xlsx for the temp file
         tmp = dest.parent / (dest.name.replace(".partial", ".tmp.xlsx"))

--- a/api_swedeb/api/services/kwic_archive_service.py
+++ b/api_swedeb/api/services/kwic_archive_service.py
@@ -1,0 +1,226 @@
+"""KWIC archive service — prepare and execute async KWIC archive generation."""
+
+from __future__ import annotations
+
+import csv
+import gzip
+import io
+import json
+import zipfile
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from loguru import logger
+
+from api_swedeb.api.services.result_store import (
+    ResultStore,
+    ResultStoreCapacityError,
+    ResultStoreNotFound,
+    TicketMeta,
+    TicketStatus,
+)
+from api_swedeb.core.configuration import ConfigValue
+from api_swedeb.schemas.bulk_archive_schema import (
+    ARCHIVE_MEDIA_TYPES,
+    ARCHIVE_SUFFIXES,
+    ArchivePrepareResponse,
+    BulkArchiveFormat,
+)
+
+# KWIC columns exposed in archive output (excludes internal identifiers)
+_ARCHIVE_COLUMNS: list[str] = [
+    "left_word",
+    "node_word",
+    "right_word",
+    "year",
+    "name",
+    "party_abbrev",
+    "gender",
+    "speech_name",
+    "speech_id",
+    "document_name",
+    "chamber_abbrev",
+]
+
+_TICKET_ROW_ID = "_ticket_row_id"
+
+
+class KWICArchiveService:
+    """Thin service that converts a ready KWIC Feather artifact into a bulk archive."""
+
+    def prepare(
+        self,
+        *,
+        source_ticket_id: str,
+        archive_format: BulkArchiveFormat,
+        result_store: ResultStore,
+    ) -> ArchivePrepareResponse:
+        """Validate the source KWIC ticket and create an archive ticket.
+
+        Raises:
+            ResultStoreNotFound: if the source ticket is missing or expired.
+            ValueError: if the source ticket is not in a ready state.
+        """
+        source_ticket: TicketMeta = result_store.require_ticket(source_ticket_id)
+        if source_ticket.status == TicketStatus.PENDING:
+            raise ValueError("Source ticket is not ready yet")
+        if source_ticket.status == TicketStatus.ERROR:
+            raise ValueError("Source ticket is in an error state")
+
+        query_meta: dict[str, Any] = {
+            "source_ticket_id": source_ticket_id,
+            "archive_format": archive_format.value,
+            "total_hits": source_ticket.total_hits,
+            "source_query": source_ticket.query_meta,
+        }
+        archive_ticket: TicketMeta = result_store.create_ticket(
+            query_meta=query_meta,
+            source_ticket_id=source_ticket_id,
+            archive_format=archive_format.value,
+        )
+
+        retry_after: int = ConfigValue("cache.ticket_poll_retry_after_seconds", default=2).resolve()
+        return ArchivePrepareResponse(
+            archive_ticket_id=archive_ticket.ticket_id,
+            status="pending",
+            source_ticket_id=source_ticket_id,
+            archive_format=archive_format.value,
+            retry_after=retry_after,
+            expires_at=archive_ticket.expires_at,
+        )
+
+    def execute_archive_task(
+        self,
+        *,
+        archive_ticket_id: str,
+        result_store: ResultStore,
+    ) -> None:
+        """Serialize the KWIC Feather artifact and mark the archive ticket ready or failed."""
+        logger.info(f"Starting KWIC execute_archive_task for archive ticket {archive_ticket_id}")
+
+        try:
+            archive_ticket: TicketMeta = result_store.require_ticket(archive_ticket_id)
+        except ResultStoreNotFound:
+            logger.warning(f"KWIC archive ticket {archive_ticket_id} not found; nothing to update")
+            return
+        except ResultStoreCapacityError:
+            logger.warning(f"Result store capacity error loading KWIC archive ticket {archive_ticket_id}")
+            return
+
+        try:
+            source_ticket_id: str | None = archive_ticket.source_ticket_id
+            archive_format_str: str | None = archive_ticket.archive_format
+
+            if source_ticket_id is None:
+                raise ValueError("Archive ticket has no source_ticket_id")
+            if archive_format_str is None:
+                raise ValueError("Archive ticket has no archive_format")
+
+            archive_format = BulkArchiveFormat(archive_format_str)
+
+            import pandas as pd  # pylint: disable=import-outside-toplevel
+
+            data: pd.DataFrame = result_store.load_artifact(source_ticket_id)
+            data = data.drop(columns=[_TICKET_ROW_ID], errors="ignore")
+
+            # Keep only the archive columns that are present in the artifact
+            cols = [c for c in _ARCHIVE_COLUMNS if c in data.columns]
+            data = data[cols]
+
+            dest_path: Path = result_store.archive_artifact_path(archive_ticket_id, archive_format_str)
+            dest_path.parent.mkdir(parents=True, exist_ok=True)
+
+            self._write(data, archive_format, dest_path)
+
+            result_store.store_archive_ready(
+                archive_ticket_id,
+                artifact_path=dest_path,
+                total_hits=len(data),
+            )
+            logger.info(f"KWIC archive ticket {archive_ticket_id} ready ({len(data)} rows)")
+
+        except ResultStoreCapacityError:
+            logger.warning(f"Result store capacity error for KWIC archive ticket {archive_ticket_id}")
+            return
+        except ResultStoreNotFound as exc:
+            logger.warning(f"Required resource not found for KWIC archive ticket {archive_ticket_id}: {exc}")
+            result_store.store_error(archive_ticket_id, message=f"Required resource not found: {exc}")
+        except Exception as exc:  # pylint: disable=broad-except
+            logger.exception(f"Error executing KWIC archive ticket {archive_ticket_id}: {exc}")
+            result_store.store_error(archive_ticket_id, message="Failed to generate KWIC archive")
+
+    # ------------------------------------------------------------------
+    # Private serialization helpers
+    # ------------------------------------------------------------------
+
+    def _write(
+        self,
+        data: "pd.DataFrame",  # noqa: F821
+        archive_format: BulkArchiveFormat,
+        dest_path: Path,
+    ) -> None:
+        import pandas as pd  # pylint: disable=import-outside-toplevel
+
+        partial = Path(str(dest_path) + ".partial")
+        partial.parent.mkdir(parents=True, exist_ok=True)
+
+        try:
+            if archive_format == BulkArchiveFormat.jsonl_gz:
+                self._write_jsonl_gz(data, partial)
+            elif archive_format == BulkArchiveFormat.csv_gz:
+                self._write_csv_gz(data, partial)
+            elif archive_format == BulkArchiveFormat.xlsx:
+                self._write_xlsx(data, partial)
+            elif archive_format == BulkArchiveFormat.zip:
+                self._write_zip_csv(data, partial)
+            else:
+                self._write_jsonl_gz(data, partial)
+
+            partial.replace(dest_path)
+        except Exception:
+            partial.unlink(missing_ok=True)
+            raise
+
+    def _write_jsonl_gz(self, data: "pd.DataFrame", dest: Path) -> None:
+        with gzip.open(str(dest), "wb", compresslevel=1) as gz:
+            for record in data.to_dict(orient="records"):
+                cleaned = {k: (None if isinstance(v, float) and v != v else v) for k, v in record.items()}
+                line = (json.dumps(cleaned, ensure_ascii=False, default=str) + "\n").encode("utf-8")
+                gz.write(line)
+
+    def _write_csv_gz(self, data: "pd.DataFrame", dest: Path) -> None:
+        buf = io.BytesIO()
+        with gzip.GzipFile(fileobj=buf, mode="wb", compresslevel=1) as gz:
+            csv_str = data.to_csv(index=False)
+            gz.write(csv_str.encode("utf-8"))
+        dest.write_bytes(buf.getvalue())
+
+    def _write_xlsx(self, data: "pd.DataFrame", dest: Path) -> None:
+        import openpyxl  # pylint: disable=import-outside-toplevel  # noqa: F401
+
+        # pandas/openpyxl validates the file extension, so we must use .xlsx for the temp file
+        tmp = dest.parent / (dest.name.replace(".partial", ".tmp.xlsx"))
+        try:
+            data.to_excel(str(tmp), index=False, engine="openpyxl")
+            tmp.replace(dest)
+        except Exception:
+            tmp.unlink(missing_ok=True)
+            raise
+
+    def _write_zip_csv(self, data: "pd.DataFrame", dest: Path) -> None:
+        csv_str = data.to_csv(index=False)
+        with zipfile.ZipFile(str(dest), "w", zipfile.ZIP_DEFLATED) as zf:
+            zf.writestr("kwic_data.csv", csv_str.encode("utf-8"))
+
+    # ------------------------------------------------------------------
+    # Reuse ArchiveTicketService helpers for status / file response
+    # ------------------------------------------------------------------
+
+    def _build_manifest(self, archive_ticket: TicketMeta) -> dict:
+        return {
+            "archive_ticket_id": archive_ticket.ticket_id,
+            "source_ticket_id": archive_ticket.source_ticket_id,
+            "archive_format": archive_ticket.archive_format,
+            "generated_at": datetime.now(UTC).isoformat(),
+        }

--- a/api_swedeb/api/services/kwic_archive_service.py
+++ b/api_swedeb/api/services/kwic_archive_service.py
@@ -3,11 +3,9 @@
 from __future__ import annotations
 
 import gzip
-import io
 import json
 import math
 import zipfile
-from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -186,11 +184,8 @@ class KWICArchiveService:
                 gz.write(line)
 
     def _write_csv_gz(self, data: "pd.DataFrame", dest: Path) -> None:
-        buf = io.BytesIO()
-        with gzip.GzipFile(fileobj=buf, mode="wb", compresslevel=1) as gz:
-            csv_str = data.to_csv(index=False)
-            gz.write(csv_str.encode("utf-8"))
-        dest.write_bytes(buf.getvalue())
+        with gzip.open(str(dest), "wt", compresslevel=1, encoding="utf-8") as gz:
+            data.to_csv(gz, index=False)
 
     def _write_xlsx(self, data: "pd.DataFrame", dest: Path) -> None:
 
@@ -204,18 +199,8 @@ class KWICArchiveService:
             raise
 
     def _write_zip_csv(self, data: "pd.DataFrame", dest: Path) -> None:
-        csv_str = data.to_csv(index=False)
         with zipfile.ZipFile(str(dest), "w", zipfile.ZIP_DEFLATED) as zf:
-            zf.writestr("kwic_data.csv", csv_str.encode("utf-8"))
+            with zf.open("kwic_data.csv", "w") as entry:
+                data.to_csv(entry, index=False)
 
-    # ------------------------------------------------------------------
-    # Reuse ArchiveTicketService helpers for status / file response
-    # ------------------------------------------------------------------
 
-    def _build_manifest(self, archive_ticket: TicketMeta) -> dict:
-        return {
-            "archive_ticket_id": archive_ticket.ticket_id,
-            "source_ticket_id": archive_ticket.source_ticket_id,
-            "archive_format": archive_ticket.archive_format,
-            "generated_at": datetime.now(UTC).isoformat(),
-        }

--- a/api_swedeb/api/services/kwic_archive_service.py
+++ b/api_swedeb/api/services/kwic_archive_service.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import gzip
 import io
 import json
+import math
 import zipfile
 from datetime import UTC, datetime
 from pathlib import Path
@@ -180,8 +181,6 @@ class KWICArchiveService:
     def _write_jsonl_gz(self, data: "pd.DataFrame", dest: Path) -> None:
         with gzip.open(str(dest), "wb", compresslevel=1) as gz:
             for record in data.to_dict(orient="records"):
-                import math  # pylint: disable=import-outside-toplevel
-
                 cleaned = {k: (None if isinstance(v, float) and math.isnan(v) else v) for k, v in record.items()}
                 line = (json.dumps(cleaned, ensure_ascii=False, default=str) + "\n").encode("utf-8")
                 gz.write(line)

--- a/api_swedeb/api/v1/endpoints/downloads_router.py
+++ b/api_swedeb/api/v1/endpoints/downloads_router.py
@@ -4,18 +4,13 @@ Provides tool-agnostic endpoints for polling and downloading bulk archive ticket
 so the standalone retrieval page can work without knowing the originating tool type.
 """
 
-from fastapi import APIRouter, Depends, HTTPException
-from fastapi.responses import FileResponse
+from fastapi import APIRouter, Depends, HTTPException, Response
 
 from api_swedeb.api.dependencies import get_archive_ticket_service, get_result_store
 from api_swedeb.api.services.archive_ticket_service import ArchiveTicketService
-from api_swedeb.api.services.result_store import ResultStore, ResultStoreNotFound, TicketMeta, TicketStatus
-from api_swedeb.schemas.bulk_archive_schema import (
-    ARCHIVE_MEDIA_TYPES,
-    ARCHIVE_SUFFIXES,
-    ArchiveTicketStatus,
-    BulkArchiveFormat,
-)
+from api_swedeb.api.services.result_store import ResultStore, ResultStoreNotFound
+from api_swedeb.core.configuration.inject import ConfigValue
+from api_swedeb.schemas.bulk_archive_schema import ArchiveTicketStatus
 
 router = APIRouter(prefix="/v1/downloads", tags=["downloads"])
 
@@ -27,6 +22,7 @@ router = APIRouter(prefix="/v1/downloads", tags=["downloads"])
 )
 async def get_archive_status(
     archive_ticket_id: str,
+    response: Response,
     archive_ticket_service: ArchiveTicketService = Depends(get_archive_ticket_service),
     result_store: ResultStore = Depends(get_result_store),
 ) -> ArchiveTicketStatus:
@@ -34,11 +30,16 @@ async def get_archive_status(
 
     Returns HTTP 200 for all terminal states (ready, error) and pending states.
     Returns HTTP 404 only when the ticket has expired or never existed.
+    Sets a Retry-After header when the ticket is still pending.
     """
     try:
-        return archive_ticket_service.get_status(archive_ticket_id, result_store)
+        status = archive_ticket_service.get_status(archive_ticket_id, result_store)
     except ResultStoreNotFound as e:
         raise HTTPException(status_code=404, detail="Archive ticket not found or expired") from e
+    if status.status == "pending":
+        retry_after: int = ConfigValue("cache.ticket_poll_retry_after_seconds", default=2).resolve()
+        response.headers["Retry-After"] = str(retry_after)
+    return status
 
 
 @router.get(
@@ -47,37 +48,15 @@ async def get_archive_status(
 )
 async def download_archive(
     archive_ticket_id: str,
+    archive_ticket_service: ArchiveTicketService = Depends(get_archive_ticket_service),
     result_store: ResultStore = Depends(get_result_store),
 ):
     """Stream the archive artifact for a ready archive ticket.
 
     Works for any tool type — the ticket carries the format and artifact path.
     """
-    try:
-        ticket: TicketMeta = result_store.require_ticket(archive_ticket_id)
-    except ResultStoreNotFound as e:
-        raise HTTPException(status_code=404, detail="Archive ticket not found or expired") from e
-
-    if ticket.status == TicketStatus.ERROR:
-        raise HTTPException(status_code=409, detail=ticket.error or "Archive preparation failed")
-    if ticket.status != TicketStatus.READY:
-        raise HTTPException(status_code=409, detail="Archive is not ready yet")
-    if ticket.artifact_path is None or not ticket.artifact_path.exists():
-        raise HTTPException(status_code=410, detail="Archive file no longer available")
-
-    archive_format_str: str = ticket.archive_format or BulkArchiveFormat.jsonl_gz.value
-    try:
-        archive_format = BulkArchiveFormat(archive_format_str)
-    except ValueError:
-        archive_format = BulkArchiveFormat.jsonl_gz
-
-    media_type: str = ARCHIVE_MEDIA_TYPES.get(archive_format, "application/octet-stream")
-    suffix: str = ARCHIVE_SUFFIXES.get(archive_format, f".{archive_format_str}")
-    filename: str = f"archive_{archive_ticket_id}{suffix}"
-
-    try:
-        result_store.touch_ticket(archive_ticket_id)
-    except ResultStoreNotFound as e:
-        raise HTTPException(status_code=404, detail="Archive ticket not found or expired") from e
-
-    return FileResponse(path=str(ticket.artifact_path), media_type=media_type, filename=filename)
+    return archive_ticket_service.build_file_response(
+        archive_ticket_id=archive_ticket_id,
+        filename_stem="archive",
+        result_store=result_store,
+    )

--- a/api_swedeb/api/v1/endpoints/tool_router.py
+++ b/api_swedeb/api/v1/endpoints/tool_router.py
@@ -12,6 +12,7 @@ from api_swedeb.api.dependencies import (
     get_cwb_corpus,
     get_cwb_corpus_opts,
     get_download_service,
+    get_kwic_archive_service,
     get_kwic_service,
     get_kwic_ticket_service,
     get_result_store,
@@ -24,6 +25,7 @@ from api_swedeb.api.params import CommonQueryParams
 from api_swedeb.api.services.archive_ticket_service import ArchiveTicketService
 from api_swedeb.api.services.corpus_loader import CorpusLoader
 from api_swedeb.api.services.download_service import DownloadService
+from api_swedeb.api.services.kwic_archive_service import KWICArchiveService
 from api_swedeb.api.services.kwic_service import KWICService
 from api_swedeb.api.services.kwic_ticket_service import DEFAULT_PAGE_SIZE, KWICTicketService
 from api_swedeb.api.services.ngrams_service import NGramsService
@@ -255,6 +257,53 @@ async def download_kwic_ticket(
         media_type="application/zip",
         headers={"Content-Disposition": f'attachment; filename="kwic_{ticket_id}.zip"'},
     )
+
+
+# ---------------------------------------------------------------------------
+# Async bulk archive: KWIC
+# ---------------------------------------------------------------------------
+
+
+@router.post(
+    "/kwic/archive/{ticket_id}",
+    response_model=ArchivePrepareResponse,
+    status_code=202,
+    summary="Prepare a bulk archive from a KWIC ticket",
+)
+async def prepare_kwic_bulk_archive(
+    ticket_id: str,
+    request: Request,
+    background_tasks: BackgroundTasks,
+    archive_format: BulkArchiveFormat = Query(default=BulkArchiveFormat.jsonl_gz),
+    kwic_archive_service: KWICArchiveService = Depends(get_kwic_archive_service),
+    result_store: ResultStore = Depends(get_result_store),
+) -> ArchivePrepareResponse:
+    """Start async archive generation for a ready KWIC ticket.
+
+    Returns 202 with an ``archive_ticket_id`` to poll for completion via
+    ``GET /v1/downloads/{archive_ticket_id}``.
+    """
+    try:
+        response: ArchivePrepareResponse = kwic_archive_service.prepare(
+            source_ticket_id=ticket_id,
+            archive_format=archive_format,
+            result_store=result_store,
+        )
+    except ResultStoreNotFound as e:
+        raise HTTPException(status_code=404, detail="Source ticket not found or expired") from e
+    except ValueError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+
+    retrieval_url = str(request.base_url).rstrip("/") + f"/download/{response.archive_ticket_id}"
+    response = response.model_copy(update={"retrieval_url": retrieval_url})
+
+    background_tasks.add_task(
+        kwic_archive_service.execute_archive_task,
+        archive_ticket_id=response.archive_ticket_id,
+        result_store=result_store,
+    )
+
+    return response
 
 
 @router.get("/word_trends/{search}", response_model=WordTrendsResult)

--- a/api_swedeb/api/v1/endpoints/tool_router.py
+++ b/api_swedeb/api/v1/endpoints/tool_router.py
@@ -46,8 +46,6 @@ from api_swedeb.mappers.word_trends import (
     word_trends_to_api_model,
 )
 from api_swedeb.schemas.bulk_archive_schema import (
-    ARCHIVE_MEDIA_TYPES,
-    ARCHIVE_SUFFIXES,
     ArchivePrepareResponse,
     ArchiveTicketStatus,
     BulkArchiveFormat,
@@ -543,36 +541,14 @@ async def get_word_trend_speeches_archive_status(
 )
 async def download_word_trend_speeches_bulk_archive(
     archive_ticket_id: str,
+    archive_ticket_service: ArchiveTicketService = Depends(get_archive_ticket_service),
     result_store: ResultStore = Depends(get_result_store),
 ):
-    from fastapi.responses import FileResponse  # pylint: disable=import-outside-toplevel
-
-    try:
-        ticket: TicketMeta = result_store.require_ticket(archive_ticket_id)
-    except ResultStoreNotFound as e:
-        raise HTTPException(status_code=404, detail="Archive ticket not found or expired") from e
-
-    if ticket.status == TicketStatus.ERROR:
-        raise HTTPException(status_code=409, detail=ticket.error or "Archive preparation failed")
-    if ticket.status != TicketStatus.READY:
-        raise HTTPException(status_code=409, detail="Archive is not ready yet")
-    if ticket.artifact_path is None or not ticket.artifact_path.exists():
-        raise HTTPException(status_code=410, detail="Archive file no longer available")
-
-    archive_format_str: str = ticket.archive_format or BulkArchiveFormat.jsonl_gz.value
-    try:
-        archive_format = BulkArchiveFormat(archive_format_str)
-    except ValueError:
-        archive_format = BulkArchiveFormat.jsonl_gz
-
-    media_type: str = ARCHIVE_MEDIA_TYPES.get(archive_format, "application/octet-stream")
-    suffix: str = ARCHIVE_SUFFIXES.get(archive_format, f".{archive_format_str}")
-    filename: str = f"word_trend_speeches_archive_{archive_ticket_id}{suffix}"
-    try:
-        result_store.touch_ticket(archive_ticket_id)
-    except ResultStoreNotFound as e:
-        raise HTTPException(status_code=404, detail="Archive ticket not found or expired") from e
-    return FileResponse(path=str(ticket.artifact_path), media_type=media_type, filename=filename)
+    return archive_ticket_service.build_file_response(
+        archive_ticket_id=archive_ticket_id,
+        filename_stem="word_trend_speeches_archive",
+        result_store=result_store,
+    )
 
 
 @router.get("/word_trend_hits/{search}", response_model=SearchHits)
@@ -854,36 +830,14 @@ async def get_speeches_archive_status(
 )
 async def download_speeches_bulk_archive(
     archive_ticket_id: str,
+    archive_ticket_service: ArchiveTicketService = Depends(get_archive_ticket_service),
     result_store: ResultStore = Depends(get_result_store),
 ):
-    from fastapi.responses import FileResponse  # pylint: disable=import-outside-toplevel
-
-    try:
-        ticket: TicketMeta = result_store.require_ticket(archive_ticket_id)
-    except ResultStoreNotFound as e:
-        raise HTTPException(status_code=404, detail="Archive ticket not found or expired") from e
-
-    if ticket.status == TicketStatus.ERROR:
-        raise HTTPException(status_code=409, detail=ticket.error or "Archive preparation failed")
-    if ticket.status != TicketStatus.READY:
-        raise HTTPException(status_code=409, detail="Archive is not ready yet")
-    if ticket.artifact_path is None or not ticket.artifact_path.exists():
-        raise HTTPException(status_code=410, detail="Archive file no longer available")
-
-    archive_format_str: str = ticket.archive_format or BulkArchiveFormat.jsonl_gz.value
-    try:
-        archive_format = BulkArchiveFormat(archive_format_str)
-    except ValueError:
-        archive_format = BulkArchiveFormat.jsonl_gz
-
-    media_type: str = ARCHIVE_MEDIA_TYPES.get(archive_format, "application/octet-stream")
-    suffix: str = ARCHIVE_SUFFIXES.get(archive_format, f".{archive_format_str}")
-    filename: str = f"speeches_archive_{archive_ticket_id}{suffix}"
-    try:
-        result_store.touch_ticket(archive_ticket_id)
-    except ResultStoreNotFound as e:
-        raise HTTPException(status_code=404, detail="Archive ticket not found or expired") from e
-    return FileResponse(path=str(ticket.artifact_path), media_type=media_type, filename=filename)
+    return archive_ticket_service.build_file_response(
+        archive_ticket_id=archive_ticket_id,
+        filename_stem="speeches_archive",
+        result_store=result_store,
+    )
 
 
 @router.post("/speeches/download")

--- a/api_swedeb/schemas/bulk_archive_schema.py
+++ b/api_swedeb/schemas/bulk_archive_schema.py
@@ -11,6 +11,7 @@ class BulkArchiveFormat(StrEnum):
     jsonl_gz = "jsonl_gz"
     zip = "zip"
     csv_gz = "csv_gz"
+    xlsx = "xlsx"
 
     @classmethod
     def _missing_(cls, value: object) -> "BulkArchiveFormat | None":
@@ -26,12 +27,14 @@ ARCHIVE_SUFFIXES: dict[BulkArchiveFormat, str] = {
     BulkArchiveFormat.jsonl_gz: ".jsonl.gz",
     BulkArchiveFormat.zip: ".zip",
     BulkArchiveFormat.csv_gz: ".csv.gz",
+    BulkArchiveFormat.xlsx: ".xlsx",
 }
 
 ARCHIVE_MEDIA_TYPES: dict[BulkArchiveFormat, str] = {
     BulkArchiveFormat.jsonl_gz: "application/gzip",
     BulkArchiveFormat.zip: "application/zip",
     BulkArchiveFormat.csv_gz: "application/gzip",
+    BulkArchiveFormat.xlsx: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
 }
 
 

--- a/docs/change_requests/KWIC_ASYNC_ARCHIVE_EXPORT.md
+++ b/docs/change_requests/KWIC_ASYNC_ARCHIVE_EXPORT.md
@@ -8,7 +8,7 @@
 
 ## Summary
 
-Add `POST /v1/tools/kwic/archive/{ticket_id}` to offload KWIC export to a background job, return a `retrieval_url` from the prepare response, and wire the frontend copy-link button in the same way as the existing export components. Excel generation is done server-side via `openpyxl`; no client-side fallback is needed.
+Add `POST /v1/tools/kwic/archive/{ticket_id}` to offload KWIC export to a background job, return a `retrieval_url` from the prepare response, and wire the frontend copy-link button in the same way as the existing export components. Excel generation git pullis done server-side via `openpyxl`; no client-side fallback is needed.
 
 ## Problem
 
@@ -210,6 +210,13 @@ sequenceDiagram
   - [ ] Schedule `execute_archive_task` as `BackgroundTasks` job
   - [ ] Return `ArchivePrepareResponse` (202)
 
+**Completed (this branch):**
+- [x] `ArchiveTicketService.build_file_response()` extracted — ticket validation, format parsing, `touch_ticket`, and `FileResponse` are now in one place; all three bulk-archive download endpoints delegate to it
+- [x] `retrieval_url` included in `ArchivePrepareResponse` schema (`str | None`)
+- [x] `retrieval_url` computed and set in both existing prepare endpoints (`/word_trend_speeches/archive/{ticket_id}` and `/speeches/archive/{ticket_id}`)
+- [x] `GET /v1/downloads/{archive_ticket_id}` — generic status poll for any ticket
+- [x] `GET /v1/downloads/{archive_ticket_id}/download` — generic file stream for any ready ticket
+
 ### Backend tests
 
 - [ ] Create `tests/api_swedeb/api/test_kwic_archive_endpoints.py`
@@ -219,6 +226,10 @@ sequenceDiagram
   - [ ] `GET /v1/downloads/{id}` returns pending/ready status
   - [ ] `GET /v1/downloads/{id}/download` streams artifact for ready ticket
 
+**Completed (this branch):**
+- [x] `test_downloads_router.py` — covers `GET /v1/downloads/{id}` status (all states) and `GET /v1/downloads/{id}/download`
+- [x] `test_downloads_router.py` — verifies `retrieval_url` and `expires_at` are present in prepare responses for both existing tools
+
 ### Frontend
 
 - [ ] Add `archiveRetrievalUrl: null` to `kwicDataStore` state
@@ -227,6 +238,8 @@ sequenceDiagram
 - [ ] Add `linkCopied` ref and `copyRetrievalLink()` to `kwicDataTable.vue`
 - [ ] Show copy-link button when `archiveRetrievalUrl` is set
 - [ ] Remove client-side Excel generation (ExcelJS/JSZip path in `kwicDataStore.js`)
+
+**Note:** `archiveRetrievalUrl` and the `downloadKwicArchive()` pattern are already implemented in `downloadDataStore.js` and `wordTrendsDataStore.js`. `kwicDataStore.js` still uses client-side ExcelJS/JSZip; the backend endpoint does not exist yet so these cannot be removed yet.
 
 ### Validation
 

--- a/docs/change_requests/KWIC_ASYNC_ARCHIVE_EXPORT.md
+++ b/docs/change_requests/KWIC_ASYNC_ARCHIVE_EXPORT.md
@@ -198,19 +198,18 @@ sequenceDiagram
 
 ### Backend
 
-- [ ] Add `xlsx` to `BulkArchiveFormat` enum (or define a KWIC-specific format enum)
-- [ ] Create `api_swedeb/api/services/kwic_archive_service.py` with `KWICArchiveService`
-  - [ ] `prepare()` — validates source KWIC ticket is ready, creates archive ticket, returns `ArchivePrepareResponse`
-  - [ ] `execute_archive_task()` — reads KWIC Feather, serializes to target format (CSV / JSONL / xlsx), writes artifact, marks ticket ready or failed
-  - [ ] Excel serialization via `openpyxl` (or `pandas.to_excel`)
-- [ ] Wire `get_kwic_archive_service()` singleton in `api_swedeb/api/dependencies.py`
-- [ ] Add `POST /v1/tools/kwic/archive/{ticket_id}` to `tool_router.py`
-  - [ ] Validate source ticket, call `kwic_archive_service.prepare()`
-  - [ ] Compute `retrieval_url` from `request.base_url`
-  - [ ] Schedule `execute_archive_task` as `BackgroundTasks` job
-  - [ ] Return `ArchivePrepareResponse` (202)
+- [x] Add `xlsx` to `BulkArchiveFormat` enum (or define a KWIC-specific format enum)
+- [x] Create `api_swedeb/api/services/kwic_archive_service.py` with `KWICArchiveService`
+  - [x] `prepare()` — validates source KWIC ticket is ready, creates archive ticket, returns `ArchivePrepareResponse`
+  - [x] `execute_archive_task()` — reads KWIC Feather, serializes to target format (CSV / JSONL / xlsx), writes artifact, marks ticket ready or failed
+  - [x] Excel serialization via `openpyxl` (or `pandas.to_excel`)
+- [x] Wire `get_kwic_archive_service()` singleton in `api_swedeb/api/dependencies.py`
+- [x] Add `POST /v1/tools/kwic/archive/{ticket_id}` to `tool_router.py`
+  - [x] Validate source ticket, call `kwic_archive_service.prepare()`
+  - [x] Compute `retrieval_url` from `request.base_url`
+  - [x] Schedule `execute_archive_task` as `BackgroundTasks` job
+  - [x] Return `ArchivePrepareResponse` (202)
 
-**Completed (this branch):**
 - [x] `ArchiveTicketService.build_file_response()` extracted — ticket validation, format parsing, `touch_ticket`, and `FileResponse` are now in one place; all three bulk-archive download endpoints delegate to it
 - [x] `retrieval_url` included in `ArchivePrepareResponse` schema (`str | None`)
 - [x] `retrieval_url` computed and set in both existing prepare endpoints (`/word_trend_speeches/archive/{ticket_id}` and `/speeches/archive/{ticket_id}`)
@@ -219,12 +218,12 @@ sequenceDiagram
 
 ### Backend tests
 
-- [ ] Create `tests/api_swedeb/api/test_kwic_archive_endpoints.py`
-  - [ ] Prepare endpoint returns 202 with `retrieval_url` and `expires_at`
-  - [ ] Pending source ticket returns 409
-  - [ ] Missing source ticket returns 404
-  - [ ] `GET /v1/downloads/{id}` returns pending/ready status
-  - [ ] `GET /v1/downloads/{id}/download` streams artifact for ready ticket
+- [x] Create `tests/api_swedeb/api/test_kwic_archive_endpoints.py`
+  - [x] Prepare endpoint returns 202 with `retrieval_url` and `expires_at`
+  - [x] Pending source ticket returns 409
+  - [x] Missing source ticket returns 404
+  - [x] `execute_archive_task` writes valid artifact for `jsonl_gz`, `csv_gz`, and `xlsx` formats
+  - [x] `execute_archive_task` marks ticket ERROR when source artifact is missing
 
 **Completed (this branch):**
 - [x] `test_downloads_router.py` — covers `GET /v1/downloads/{id}` status (all states) and `GET /v1/downloads/{id}/download`
@@ -232,20 +231,18 @@ sequenceDiagram
 
 ### Frontend
 
-- [ ] Add `archiveRetrievalUrl: null` to `kwicDataStore` state
-- [ ] Clear `archiveRetrievalUrl` in `resetTicketState()`
-- [ ] Add `downloadKwicArchive(format)` action: POST to `/tools/kwic/archive/{ticketId}`, store `retrieval_url`
-- [ ] Add `linkCopied` ref and `copyRetrievalLink()` to `kwicDataTable.vue`
-- [ ] Show copy-link button when `archiveRetrievalUrl` is set
-- [ ] Remove client-side Excel generation (ExcelJS/JSZip path in `kwicDataStore.js`)
-
-**Note:** `archiveRetrievalUrl` and the `downloadKwicArchive()` pattern are already implemented in `downloadDataStore.js` and `wordTrendsDataStore.js`. `kwicDataStore.js` still uses client-side ExcelJS/JSZip; the backend endpoint does not exist yet so these cannot be removed yet.
+- [x] Add `archiveRetrievalUrl: null` to `kwicDataStore` state
+- [x] Clear `archiveRetrievalUrl` in `resetTicketState()`
+- [x] Add `downloadKwicArchive(format)` action: POST to `/tools/kwic/archive/{ticketId}`, store `retrieval_url`
+- [x] Add `linkCopied` ref and `copyRetrievalLink()` to `kwicDataTable.vue`
+- [x] Show copy-link button when `archiveRetrievalUrl` is set
+- [x] Remove client-side Excel generation (ExcelJS/JSZip path in `kwicDataStore.js`)
 
 ### Validation
 
-- [ ] `pnpm lint` clean
-- [ ] `make lint` / `make tidy` clean
-- [ ] All new and existing archive/download tests pass
+- [x] `pnpm lint` clean
+- [x] `make tidy` clean
+- [x] All new archive/download tests pass (12/12)
 - [ ] Manual smoke test: submit KWIC query → export → copy link → open in new tab → download
 
 ## Open Questions

--- a/tests/api_swedeb/api/test_kwic_archive_endpoints.py
+++ b/tests/api_swedeb/api/test_kwic_archive_endpoints.py
@@ -19,13 +19,14 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from api_swedeb.api.dependencies import (
+    get_archive_ticket_service,
     get_kwic_archive_service,
     get_result_store,
 )
 from api_swedeb.api.services.archive_ticket_service import ArchiveTicketService
 from api_swedeb.api.services.kwic_archive_service import KWICArchiveService
 from api_swedeb.api.services.result_store import ResultStore, TicketMeta, TicketStatus
-from api_swedeb.api.v1.endpoints import tool_router
+from api_swedeb.api.v1.endpoints import downloads_router, tool_router
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -114,9 +115,11 @@ def _kwic_archive_client(tmp_path: Path) -> Generator[tuple[TestClient, ResultSt
 
     app = FastAPI()
     app.include_router(tool_router.router)
+    app.include_router(downloads_router.router)
 
     app.dependency_overrides[get_result_store] = lambda: store
     app.dependency_overrides[get_kwic_archive_service] = KWICArchiveService
+    app.dependency_overrides[get_archive_ticket_service] = ArchiveTicketService
 
     try:
         with TestClient(app, raise_server_exceptions=True) as client:
@@ -304,10 +307,12 @@ def test_get_kwic_archive_status_via_downloads_router(kwic_archive_client):
     prepare_r = client.post(f"/v1/tools/kwic/archive/{source.ticket_id}")
     archive_ticket_id = prepare_r.json()["archive_ticket_id"]
 
-    # The background task runs inline in TestClient; status may already be ready
-    _ = client.get(f"/v1/downloads/{archive_ticket_id}")
-    # downloads_router is not included in this test app; just verify the archive ticket was created
-    assert archive_ticket_id in store.require_ticket(archive_ticket_id).ticket_id
+    # The background task runs inline in TestClient; status may already be ready or pending
+    status_r = client.get(f"/v1/downloads/{archive_ticket_id}")
+    assert status_r.status_code == 200
+    body = status_r.json()
+    assert body["archive_ticket_id"] == archive_ticket_id
+    assert body["status"] in {"pending", "ready"}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/api_swedeb/api/test_kwic_archive_endpoints.py
+++ b/tests/api_swedeb/api/test_kwic_archive_endpoints.py
@@ -12,7 +12,6 @@ import gzip
 import json
 from pathlib import Path
 from typing import Generator
-from unittest.mock import MagicMock, patch
 
 import pandas as pd
 import pytest
@@ -23,6 +22,7 @@ from api_swedeb.api.dependencies import (
     get_kwic_archive_service,
     get_result_store,
 )
+from api_swedeb.api.services.archive_ticket_service import ArchiveTicketService
 from api_swedeb.api.services.kwic_archive_service import KWICArchiveService
 from api_swedeb.api.services.result_store import ResultStore, TicketMeta, TicketStatus
 from api_swedeb.api.v1.endpoints import tool_router
@@ -240,8 +240,10 @@ def test_execute_archive_task_produces_csv_gz_artifact(tmp_path):
 
     ready = store.require_ticket(archive_ticket.ticket_id)
     assert ready.status == TicketStatus.READY
+    assert ready.artifact_path is not None
+    assert ready.artifact_path.exists()
     content = gzip.decompress(ready.artifact_path.read_bytes()).decode("utf-8")
-    lines = [l for l in content.splitlines() if l]
+    lines = [line for line in content.splitlines() if line]
     assert lines[0].startswith("left_word")
     assert len(lines) == len(SAMPLE_KWIC_ROWS) + 1  # header + rows
 
@@ -260,12 +262,15 @@ def test_execute_archive_task_produces_xlsx_artifact(tmp_path):
 
     ready = store.require_ticket(archive_ticket.ticket_id)
     assert ready.status == TicketStatus.READY
+    assert ready.artifact_path is not None
+    assert ready.artifact_path.exists()
     assert ready.artifact_path.suffix == ".xlsx"
 
-    import openpyxl  # noqa: F401
+    import openpyxl  # noqa: F401 ; # pylint: disable=import-outside-toplevel
 
     wb = openpyxl.load_workbook(str(ready.artifact_path))
     ws = wb.active
+    assert ws is not None
     rows = list(ws.iter_rows(values_only=True))
     assert len(rows) == len(SAMPLE_KWIC_ROWS) + 1  # header + data rows
 
@@ -300,7 +305,7 @@ def test_get_kwic_archive_status_via_downloads_router(kwic_archive_client):
     archive_ticket_id = prepare_r.json()["archive_ticket_id"]
 
     # The background task runs inline in TestClient; status may already be ready
-    status_r = client.get(f"/v1/downloads/{archive_ticket_id}")
+    _ = client.get(f"/v1/downloads/{archive_ticket_id}")
     # downloads_router is not included in this test app; just verify the archive ticket was created
     assert archive_ticket_id in store.require_ticket(archive_ticket_id).ticket_id
 
@@ -312,7 +317,6 @@ def test_get_kwic_archive_status_via_downloads_router(kwic_archive_client):
 
 def test_kwic_archive_artifact_is_downloadable(tmp_path):
     """Ready KWIC archive artifacts can be streamed via ArchiveTicketService.build_file_response."""
-    from api_swedeb.api.services.archive_ticket_service import ArchiveTicketService
 
     store = make_result_store(tmp_path)
     asyncio.run(store.startup())

--- a/tests/api_swedeb/api/test_kwic_archive_endpoints.py
+++ b/tests/api_swedeb/api/test_kwic_archive_endpoints.py
@@ -1,0 +1,331 @@
+"""Endpoint tests for the KWIC async archive route.
+
+Strategy: TestClient with dependency overrides; real in-memory ResultStore
+so state transitions are exercised end-to-end, mocked KWICArchiveService
+where needed to avoid actual serialization.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import gzip
+import json
+from pathlib import Path
+from typing import Generator
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from api_swedeb.api.dependencies import (
+    get_kwic_archive_service,
+    get_result_store,
+)
+from api_swedeb.api.services.kwic_archive_service import KWICArchiveService
+from api_swedeb.api.services.result_store import ResultStore, TicketMeta, TicketStatus
+from api_swedeb.api.v1.endpoints import tool_router
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+SAMPLE_KWIC_ROWS = [
+    {
+        "left_word": "om",
+        "node_word": "demokrati",
+        "right_word": "är",
+        "year": 1990,
+        "name": "Alice",
+        "party_abbrev": "S",
+        "gender": "kvinna",
+        "speech_name": "prot-1990--1_1",
+        "speech_id": "i-1",
+        "document_name": "prot-1990--1",
+        "chamber_abbrev": "FK",
+        "_ticket_row_id": 0,
+    },
+    {
+        "left_word": "stark",
+        "node_word": "demokrati",
+        "right_word": "kräver",
+        "year": 1991,
+        "name": "Bob",
+        "party_abbrev": "M",
+        "gender": "man",
+        "speech_name": "prot-1991--1_2",
+        "speech_id": "i-2",
+        "document_name": "prot-1991--1",
+        "chamber_abbrev": "AK",
+        "_ticket_row_id": 1,
+    },
+]
+
+
+def make_result_store(tmp_path: Path) -> ResultStore:
+    return ResultStore(
+        root_dir=tmp_path,
+        result_ttl_seconds=600,
+        cleanup_interval_seconds=0,
+        max_artifact_bytes=10_000_000,
+        max_pending_jobs=10,
+        max_page_size=500,
+    )
+
+
+def make_ready_kwic_ticket(store: ResultStore) -> TicketMeta:
+    """Create a READY KWIC source ticket with a Feather artifact."""
+    ticket = store.create_ticket(query_meta={"search": "demokrati"})
+    frame = pd.DataFrame(SAMPLE_KWIC_ROWS)
+    store.store_ready(
+        ticket.ticket_id,
+        df=frame,
+        speech_ids=["i-1", "i-2"],
+        manifest_meta={"search": "demokrati", "total_hits": 2},
+    )
+    return store.require_ticket(ticket.ticket_id)
+
+
+def make_ready_kwic_archive(store: ResultStore, source_ticket_id: str) -> TicketMeta:
+    """Execute a real KWIC archive task and return the ready archive ticket."""
+    archive_ticket = store.create_ticket(
+        source_ticket_id=source_ticket_id,
+        archive_format="jsonl_gz",
+    )
+    svc = KWICArchiveService()
+    svc.execute_archive_task(
+        archive_ticket_id=archive_ticket.ticket_id,
+        result_store=store,
+    )
+    return store.require_ticket(archive_ticket.ticket_id)
+
+
+# ---------------------------------------------------------------------------
+# Fixture: TestClient with dependency overrides
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(name="kwic_archive_client")
+def _kwic_archive_client(tmp_path: Path) -> Generator[tuple[TestClient, ResultStore], None, None]:
+    """Yield (client, store) with a real in-memory ResultStore."""
+    store = make_result_store(tmp_path)
+    asyncio.run(store.startup())
+
+    app = FastAPI()
+    app.include_router(tool_router.router)
+
+    app.dependency_overrides[get_result_store] = lambda: store
+    app.dependency_overrides[get_kwic_archive_service] = KWICArchiveService
+
+    try:
+        with TestClient(app, raise_server_exceptions=True) as client:
+            yield client, store
+    finally:
+        asyncio.run(store.shutdown())
+
+
+# ---------------------------------------------------------------------------
+# Tests: POST /kwic/archive/{ticket_id} — prepare
+# ---------------------------------------------------------------------------
+
+
+def test_prepare_kwic_archive_returns_202_with_archive_ticket_id(kwic_archive_client):
+    client, store = kwic_archive_client
+    source = make_ready_kwic_ticket(store)
+
+    r = client.post(
+        f"/v1/tools/kwic/archive/{source.ticket_id}",
+        params={"archive_format": "jsonl_gz"},
+    )
+
+    assert r.status_code == 202
+    body = r.json()
+    assert "archive_ticket_id" in body
+    assert body["status"] == "pending"
+    assert body["source_ticket_id"] == source.ticket_id
+    assert body["archive_format"] == "jsonl_gz"
+
+
+def test_prepare_kwic_archive_returns_retrieval_url(kwic_archive_client):
+    client, store = kwic_archive_client
+    source = make_ready_kwic_ticket(store)
+
+    r = client.post(f"/v1/tools/kwic/archive/{source.ticket_id}")
+
+    assert r.status_code == 202
+    body = r.json()
+    assert "retrieval_url" in body
+    assert body["retrieval_url"] is not None
+    archive_ticket_id = body["archive_ticket_id"]
+    assert archive_ticket_id in body["retrieval_url"]
+
+
+def test_prepare_kwic_archive_returns_expires_at(kwic_archive_client):
+    client, store = kwic_archive_client
+    source = make_ready_kwic_ticket(store)
+
+    r = client.post(f"/v1/tools/kwic/archive/{source.ticket_id}")
+
+    assert r.status_code == 202
+    assert r.json()["expires_at"] is not None
+
+
+def test_prepare_kwic_archive_returns_404_for_missing_source_ticket(kwic_archive_client):
+    client, _ = kwic_archive_client
+
+    r = client.post("/v1/tools/kwic/archive/nonexistent")
+    assert r.status_code == 404
+
+
+def test_prepare_kwic_archive_returns_409_for_pending_source_ticket(kwic_archive_client):
+    client, store = kwic_archive_client
+    pending = store.create_ticket(query_meta={"search": "test"})
+
+    r = client.post(f"/v1/tools/kwic/archive/{pending.ticket_id}")
+    assert r.status_code == 409
+
+
+def test_prepare_kwic_archive_accepts_xlsx_format(kwic_archive_client):
+    client, store = kwic_archive_client
+    source = make_ready_kwic_ticket(store)
+
+    r = client.post(
+        f"/v1/tools/kwic/archive/{source.ticket_id}",
+        params={"archive_format": "xlsx"},
+    )
+
+    assert r.status_code == 202
+    assert r.json()["archive_format"] == "xlsx"
+
+
+# ---------------------------------------------------------------------------
+# Tests: execute_archive_task (unit-level)
+# ---------------------------------------------------------------------------
+
+
+def test_execute_archive_task_produces_jsonl_gz_artifact(tmp_path):
+    store = make_result_store(tmp_path)
+    asyncio.run(store.startup())
+
+    source = make_ready_kwic_ticket(store)
+    archive_ticket = store.create_ticket(source_ticket_id=source.ticket_id, archive_format="jsonl_gz")
+
+    svc = KWICArchiveService()
+    svc.execute_archive_task(archive_ticket_id=archive_ticket.ticket_id, result_store=store)
+
+    ready = store.require_ticket(archive_ticket.ticket_id)
+    assert ready.status == TicketStatus.READY
+    assert ready.artifact_path is not None
+    assert ready.artifact_path.exists()
+
+    # Verify it is valid jsonl.gz with expected rows
+    records = [json.loads(line) for line in gzip.decompress(ready.artifact_path.read_bytes()).splitlines()]
+    assert len(records) == len(SAMPLE_KWIC_ROWS)
+    assert "node_word" in records[0]
+    assert "_ticket_row_id" not in records[0]
+
+    asyncio.run(store.shutdown())
+
+
+def test_execute_archive_task_produces_csv_gz_artifact(tmp_path):
+    store = make_result_store(tmp_path)
+    asyncio.run(store.startup())
+
+    source = make_ready_kwic_ticket(store)
+    archive_ticket = store.create_ticket(source_ticket_id=source.ticket_id, archive_format="csv_gz")
+
+    svc = KWICArchiveService()
+    svc.execute_archive_task(archive_ticket_id=archive_ticket.ticket_id, result_store=store)
+
+    ready = store.require_ticket(archive_ticket.ticket_id)
+    assert ready.status == TicketStatus.READY
+    content = gzip.decompress(ready.artifact_path.read_bytes()).decode("utf-8")
+    lines = [l for l in content.splitlines() if l]
+    assert lines[0].startswith("left_word")
+    assert len(lines) == len(SAMPLE_KWIC_ROWS) + 1  # header + rows
+
+    asyncio.run(store.shutdown())
+
+
+def test_execute_archive_task_produces_xlsx_artifact(tmp_path):
+    store = make_result_store(tmp_path)
+    asyncio.run(store.startup())
+
+    source = make_ready_kwic_ticket(store)
+    archive_ticket = store.create_ticket(source_ticket_id=source.ticket_id, archive_format="xlsx")
+
+    svc = KWICArchiveService()
+    svc.execute_archive_task(archive_ticket_id=archive_ticket.ticket_id, result_store=store)
+
+    ready = store.require_ticket(archive_ticket.ticket_id)
+    assert ready.status == TicketStatus.READY
+    assert ready.artifact_path.suffix == ".xlsx"
+
+    import openpyxl  # noqa: F401
+
+    wb = openpyxl.load_workbook(str(ready.artifact_path))
+    ws = wb.active
+    rows = list(ws.iter_rows(values_only=True))
+    assert len(rows) == len(SAMPLE_KWIC_ROWS) + 1  # header + data rows
+
+    asyncio.run(store.shutdown())
+
+
+def test_execute_archive_task_marks_error_when_source_missing(tmp_path):
+    store = make_result_store(tmp_path)
+    asyncio.run(store.startup())
+
+    archive_ticket = store.create_ticket(source_ticket_id="nonexistent", archive_format="jsonl_gz")
+
+    svc = KWICArchiveService()
+    svc.execute_archive_task(archive_ticket_id=archive_ticket.ticket_id, result_store=store)
+
+    ticket = store.require_ticket(archive_ticket.ticket_id)
+    assert ticket.status == TicketStatus.ERROR
+
+    asyncio.run(store.shutdown())
+
+
+# ---------------------------------------------------------------------------
+# Tests: GET /v1/downloads/{id} — status poll
+# ---------------------------------------------------------------------------
+
+
+def test_get_kwic_archive_status_via_downloads_router(kwic_archive_client):
+    client, store = kwic_archive_client
+    source = make_ready_kwic_ticket(store)
+
+    prepare_r = client.post(f"/v1/tools/kwic/archive/{source.ticket_id}")
+    archive_ticket_id = prepare_r.json()["archive_ticket_id"]
+
+    # The background task runs inline in TestClient; status may already be ready
+    status_r = client.get(f"/v1/downloads/{archive_ticket_id}")
+    # downloads_router is not included in this test app; just verify the archive ticket was created
+    assert archive_ticket_id in store.require_ticket(archive_ticket_id).ticket_id
+
+
+# ---------------------------------------------------------------------------
+# Tests: GET /v1/downloads/{id}/download — file download
+# ---------------------------------------------------------------------------
+
+
+def test_kwic_archive_artifact_is_downloadable(tmp_path):
+    """Ready KWIC archive artifacts can be streamed via ArchiveTicketService.build_file_response."""
+    from api_swedeb.api.services.archive_ticket_service import ArchiveTicketService
+
+    store = make_result_store(tmp_path)
+    asyncio.run(store.startup())
+
+    source = make_ready_kwic_ticket(store)
+    ready_archive = make_ready_kwic_archive(store, source.ticket_id)
+
+    svc = ArchiveTicketService()
+    response = svc.build_file_response(
+        archive_ticket_id=ready_archive.ticket_id,
+        filename_stem="kwic_archive",
+        result_store=store,
+    )
+    assert response.status_code == 200
+
+    asyncio.run(store.shutdown())


### PR DESCRIPTION
Introduce an asynchronous endpoint for exporting KWIC archives, allowing for large result sets to be processed without blocking the connection. This includes the addition of the `xlsx` format to the `BulkArchiveFormat` enum, the implementation of the `KWICArchiveService`, and the creation of a new POST endpoint for initiating archive exports. The solution also includes enhancements to data handling and comprehensive tests for validation and functionality.

Fixes #342