### PR TITLE
fix(downloads): correct retrieval_url path and tighten test assertions

### DIFF
--- a/api_swedeb/api/v1/endpoints/tool_router.py
+++ b/api_swedeb/api/v1/endpoints/tool_router.py
@@ -294,7 +294,7 @@ async def prepare_kwic_bulk_archive(
     except ValueError as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from exc
 
-    retrieval_url = str(request.base_url).rstrip("/") + f"/download/{response.archive_ticket_id}"
+    retrieval_url = str(request.base_url).rstrip("/") + f"/v1/downloads/{response.archive_ticket_id}"
     response = response.model_copy(update={"retrieval_url": retrieval_url})
 
     background_tasks.add_task(
@@ -544,7 +544,7 @@ async def prepare_word_trend_speeches_bulk_archive(
     except ValueError as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from exc
 
-    retrieval_url = str(request.base_url).rstrip("/") + f"/download/{response.archive_ticket_id}"
+    retrieval_url = str(request.base_url).rstrip("/") + f"/v1/downloads/{response.archive_ticket_id}"
     response = response.model_copy(update={"retrieval_url": retrieval_url})
 
     celery_enabled: bool = bool(ConfigValue("development.celery_enabled", default=False).resolve())
@@ -833,7 +833,7 @@ async def prepare_speeches_bulk_archive(
     except ValueError as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from exc
 
-    retrieval_url = str(request.base_url).rstrip("/") + f"/download/{response.archive_ticket_id}"
+    retrieval_url = str(request.base_url).rstrip("/") + f"/v1/downloads/{response.archive_ticket_id}"
     response = response.model_copy(update={"retrieval_url": retrieval_url})
 
     celery_enabled: bool = bool(ConfigValue("development.celery_enabled", default=False).resolve())

--- a/deploy-to-target.sh
+++ b/deploy-to-target.sh
@@ -42,7 +42,8 @@ examples:
 
 notes:
   - This script does NOT deploy new configuration files or containers definitions.
-    It only pulls a new image and recreates the existing quadlet setup.USAGE
+    It only pulls a new image and recreates the existing quadlet setup.
+USAGE
   exit 2
 }
 

--- a/docs/change_requests/TICKET_DOWNLOAD_URL_RETRIEVAL_PAGE.md
+++ b/docs/change_requests/TICKET_DOWNLOAD_URL_RETRIEVAL_PAGE.md
@@ -10,17 +10,17 @@
 
 The following infrastructure from `TICKET_BASED_BULK_ARCHIVE_GENERATION.md` is already in place and does not need to be re-implemented here:
 
-| Component | Status |
-|---|---|
-| `BulkArchiveFormat`, `ArchivePrepareResponse`, `ArchiveTicketStatus` schemas | ✅ Done |
+| Component                                                                             | Status |
+|---------------------------------------------------------------------------------------|--------|
+| `BulkArchiveFormat`, `ArchivePrepareResponse`, `ArchiveTicketStatus` schemas          | ✅ Done |
 | `TicketMeta` with `source_ticket_id`, `archive_format`, `artifact_path`, `expires_at` | ✅ Done |
 | `ResultStore`: archive artifact path, `store_archive_ready()`, TTL, cleanup, capacity | ✅ Done |
-| `ArchiveTicketService`: `prepare()`, `execute_archive_task()`, `get_status()` | ✅ Done |
-| Celery task and `dependencies.py` wiring | ✅ Done |
-| Tool-specific status and download endpoints (word trend speeches, speeches) | ✅ Done |
-| HTTP error responses without internal stack traces | ✅ Done |
-| Artifact access gated on ticket state; 409 for pending, 404 for missing/expired | ✅ Done |
-| UUID-based ticket IDs with sufficient entropy | ✅ Done |
+| `ArchiveTicketService`: `prepare()`, `execute_archive_task()`, `get_status()`         | ✅ Done |
+| Celery task and `dependencies.py` wiring                                              | ✅ Done |
+| Tool-specific status and download endpoints (word trend speeches, speeches)           | ✅ Done |
+| HTTP error responses without internal stack traces                                    | ✅ Done |
+| Artifact access gated on ticket state; 409 for pending, 404 for missing/expired       | ✅ Done |
+| UUID-based ticket IDs with sufficient entropy                                         | ✅ Done |
 
 ## Summary
 

--- a/tests/api_swedeb/api/test_downloads_router.py
+++ b/tests/api_swedeb/api/test_downloads_router.py
@@ -133,7 +133,7 @@ def test_prepare_wt_archive_includes_retrieval_url_and_expires_at(downloads_clie
     assert "retrieval_url" in body
     assert body["retrieval_url"] is not None
     archive_ticket_id = body["archive_ticket_id"]
-    assert archive_ticket_id in body["retrieval_url"]
+    assert f"/v1/downloads/{archive_ticket_id}" in body["retrieval_url"]
     assert "expires_at" in body
     assert body["expires_at"] is not None
 
@@ -146,7 +146,8 @@ def test_prepare_speeches_archive_includes_retrieval_url(downloads_client):
 
     assert r.status_code == 202
     body = r.json()
-    assert body.get("retrieval_url") is not None
+    archive_ticket_id = body["archive_ticket_id"]
+    assert f"/v1/downloads/{archive_ticket_id}" in body["retrieval_url"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/api_swedeb/api/test_kwic_archive_endpoints.py
+++ b/tests/api_swedeb/api/test_kwic_archive_endpoints.py
@@ -161,7 +161,7 @@ def test_prepare_kwic_archive_returns_retrieval_url(kwic_archive_client):
     assert "retrieval_url" in body
     assert body["retrieval_url"] is not None
     archive_ticket_id = body["archive_ticket_id"]
-    assert archive_ticket_id in body["retrieval_url"]
+    assert f"/v1/downloads/{archive_ticket_id}" in body["retrieval_url"]
 
 
 def test_prepare_kwic_archive_returns_expires_at(kwic_archive_client):


### PR DESCRIPTION
Update the retrieval_url construction in the archive prepare endpoints to point to the correct path `/v1/downloads/{id}` instead of the non-existent `/download/{id}`. Adjust test assertions to verify the full retrieval URL path, ensuring that future regressions are caught.

Closes #349