### PR TITLE
fix(api): add --proxy-headers to Uvicorn and silence pandas FutureWarnings

### DIFF
--- a/api_swedeb/api/services/corpus_loader.py
+++ b/api_swedeb/api/services/corpus_loader.py
@@ -252,9 +252,9 @@ class CorpusLoader:
 
     def _load_prebuilt_page_number_index(self) -> dict[str, tuple[int, int]]:
         """Compute page number ranges for each protocol based on the document index."""
-        ranges_df: pd.DataFrame = self.prebuilt_speech_index.groupby("protocol_name")[
+        ranges_df: pd.DataFrame = self.prebuilt_speech_index.groupby("protocol_name", observed=False)[
             ["page_number_start", "page_number_end"]
-        ].agg({'page_number_start': min, 'page_number_end': max})
+        ].agg({"page_number_start": "min", "page_number_end": "max"})
         page_ranges: dict[str, tuple[int, int]] = {
             str(protocol_name): (int(row['page_number_start']), int(row['page_number_end']))
             for protocol_name, row in ranges_df.iterrows()

--- a/api_swedeb/api/v1/endpoints/deprecated_endpoints.py
+++ b/api_swedeb/api/v1/endpoints/deprecated_endpoints.py
@@ -8,7 +8,7 @@ from typing import Annotated, Any
 
 import fastapi
 import pandas as pd
-from fastapi import Body, Depends, Query
+from fastapi import Body, Depends, HTTPException, Query
 from fastapi.responses import StreamingResponse
 
 from api_swedeb.api.dependencies import (
@@ -97,6 +97,8 @@ async def get_zip(
     search_service: SearchService = Depends(get_search_service),
 ) -> StreamingResponse:
     """Download speeches as ZIP file. Deprecated: use POST /speeches/download instead."""
+    if not ids:
+        raise HTTPException(status_code=400, detail="Speech ids are required")
     commons = CommonQueryParams(speech_id=ids).resolve()
     streamer = download_service.create_stream(search_service=search_service, commons=commons)
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -28,4 +28,4 @@ if [ "$#" -gt 0 ]; then
 fi
 
 log "Starting application server on port ${SWEDEB_PORT}"
-exec uvicorn main:app --host 0.0.0.0 --port ${SWEDEB_PORT}
+exec uvicorn main:app --host 0.0.0.0 --port ${SWEDEB_PORT} --proxy-headers --forwarded-allow-ips "*"

--- a/tests/api_swedeb/api/endpoints/test_deprecated_endpoints.py
+++ b/tests/api_swedeb/api/endpoints/test_deprecated_endpoints.py
@@ -1,0 +1,144 @@
+"""Unit tests for deprecated tool endpoints."""
+
+import asyncio
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+from fastapi import HTTPException
+
+from api_swedeb.api.v1.endpoints.deprecated_endpoints import (
+    get_kwic_results,
+    get_speeches_result,
+    get_word_trend_speeches_result,
+    get_zip,
+)
+from api_swedeb.schemas.speeches_schema import SpeechesResult, SpeechesResultItem
+
+
+class TestDeprecatedEndpoints:
+    def test_get_kwic_results_splits_search_and_maps_response(self):
+        commons = MagicMock()
+        corpus = MagicMock()
+        kwic_service = MagicMock()
+        kwic_service.get_kwic.return_value = pd.DataFrame(
+            [
+                {
+                    "left_word": "left context",
+                    "node_word": "search",
+                    "right_word": "right context",
+                    "year": 1971,
+                    "name": "Alice Andersson",
+                    "speech_id": "i-101",
+                }
+            ]
+        )
+
+        result = asyncio.run(
+            get_kwic_results(
+                commons=commons,
+                search="search phrase",
+                lemmatized=False,
+                words_before=3,
+                words_after=4,
+                cut_off=25,
+                corpus=corpus,
+                kwic_service=kwic_service,
+            )
+        )
+
+        kwic_service.get_kwic.assert_called_once_with(
+            corpus=corpus,
+            commons=commons,
+            keywords=["search", "phrase"],
+            lemmatized=False,
+            words_before=3,
+            words_after=4,
+            cut_off=25,
+            p_show="word",
+        )
+        assert len(result.kwic_list) == 1
+        assert result.kwic_list[0].speech_id == "i-101"
+        assert result.kwic_list[0].node_word == "search"
+
+    def test_get_word_trend_speeches_result_maps_rows(self):
+        commons = MagicMock()
+        commons.get_filter_opts.return_value = {"year": (1980, 1981)}
+        service = MagicMock()
+        service.get_speeches_for_word_trends.return_value = pd.DataFrame(
+            [
+                {
+                    "name": "Alice Andersson",
+                    "year": 1980,
+                    "speech_id": "i-201",
+                    "speech_name": "Prot 1",
+                    "node_word": "jobb",
+                }
+            ]
+        )
+
+        result = asyncio.run(
+            get_word_trend_speeches_result(
+                search="jobb,skatt",
+                commons=commons,
+                word_trends_service=service,
+            )
+        )
+
+        commons.get_filter_opts.assert_called_once_with(include_year=True)
+        service.get_speeches_for_word_trends.assert_called_once_with(
+            ["jobb", "skatt"],
+            {"year": (1980, 1981)},
+        )
+        assert len(result.speech_list) == 1
+        assert result.speech_list[0].speech_id == "i-201"
+        assert result.speech_list[0].node_word == "jobb"
+
+    def test_get_speeches_result_builds_response_model(self):
+        commons = MagicMock()
+        commons.get_filter_opts.return_value = {"speech_id": ["i-301"]}
+        search_service = MagicMock()
+        df = pd.DataFrame([{"speech_id": "i-301"}])
+        search_service.get_speeches.return_value = df
+
+        with patch("api_swedeb.api.v1.endpoints.deprecated_endpoints.speeches_to_api_model") as mapper:
+            mapper.return_value = SpeechesResult(
+                speech_list=[SpeechesResultItem(speech_id="i-301", party_abbrev="S", speech_name="Prot 2")]  # type: ignore[list-item]
+            )
+            result = asyncio.run(get_speeches_result(commons=commons, search_service=search_service))
+
+        commons.get_filter_opts.assert_called_once_with(True)
+        search_service.get_speeches.assert_called_once_with(selections={"speech_id": ["i-301"]})
+        mapper.assert_called_once_with(df)
+        assert len(result.speech_list) == 1
+        assert result.speech_list[0].speech_id == "i-301"
+        assert result.speech_list[0].party_abbrev == "S"
+
+    def test_get_zip_streams_archive_from_speech_ids(self):
+        download_service = MagicMock()
+        download_service.create_stream.return_value = lambda: iter([b"payload"])
+        search_service = MagicMock()
+        search_service.get_speaker_names.return_value = {"i-501": "Alice Andersson", "i-502": "Bob Berg"}
+        search_service.get_speeches_batch.return_value = iter(
+            [
+                ("i-501", MagicMock(paragraphs=["first speech"])),
+                ("i-502", MagicMock(text="second speech")),
+            ]
+        )
+
+        response = asyncio.run(
+            get_zip(ids=["i-501", "i-502"], download_service=download_service, search_service=search_service)
+        )
+
+        assert response.media_type == "application/zip"
+        assert response.headers["Content-Disposition"] == "attachment; filename=speeches.zip"
+        download_service.create_stream.assert_called_once()
+
+    def test_get_zip_rejects_empty_ids(self):
+        search_service = MagicMock()
+
+        with pytest.raises(HTTPException) as excinfo:
+            asyncio.run(get_zip(ids=[], search_service=search_service))
+
+        assert excinfo.value.status_code == 400
+        assert excinfo.value.detail == "Speech ids are required"

--- a/tests/api_swedeb/api/endpoints/test_tool_router.py
+++ b/tests/api_swedeb/api/endpoints/test_tool_router.py
@@ -21,22 +21,18 @@ from api_swedeb.api.v1.endpoints.tool_router import (
     download_speeches_archive_by_ticket,
     download_speeches_by_ticket,
     download_word_trend_speeches,
-    get_kwic_results,
     get_kwic_ticket_results,
     get_kwic_ticket_status,
     get_ngram_results,
     get_speech_by_id_result,
     get_speeches_page,
-    get_speeches_result,
     get_speeches_status,
     get_topics,
     get_word_hits,
     get_word_trend_speeches_page,
-    get_word_trend_speeches_result,
     get_word_trend_speeches_status,
     get_word_trends_result,
     get_year_range,
-    get_zip,
     submit_kwic_query,
     submit_speeches_query,
     submit_word_trend_speeches_query,
@@ -47,8 +43,6 @@ from api_swedeb.schemas.ngrams_schema import NGramResult, NGramResultItem
 from api_swedeb.schemas.sort_order import SortOrder
 from api_swedeb.schemas.speeches_schema import (
     SpeechesPageResult,
-    SpeechesResult,
-    SpeechesResultItem,
     SpeechesTicketStatus,
 )
 from api_swedeb.schemas.word_trends_schema import (
@@ -308,50 +302,6 @@ class TestToolRouterEndpoints:
 
         assert excinfo.value.status_code == 400
 
-    def test_get_kwic_results_splits_search_and_maps_response(self):
-        commons = MagicMock()
-        corpus = MagicMock()
-        kwic_service = MagicMock()
-        kwic_service.get_kwic.return_value = pd.DataFrame(
-            [
-                {
-                    "left_word": "left context",
-                    "node_word": "search",
-                    "right_word": "right context",
-                    "year": 1971,
-                    "name": "Alice Andersson",
-                    "speech_id": "i-101",
-                }
-            ]
-        )
-
-        result = asyncio.run(
-            get_kwic_results(
-                commons=commons,
-                search="search phrase",
-                lemmatized=False,
-                words_before=3,
-                words_after=4,
-                cut_off=25,
-                corpus=corpus,
-                kwic_service=kwic_service,
-            )
-        )
-
-        kwic_service.get_kwic.assert_called_once_with(
-            corpus=corpus,
-            commons=commons,
-            keywords=["search", "phrase"],
-            lemmatized=False,
-            words_before=3,
-            words_after=4,
-            cut_off=25,
-            p_show="word",
-        )
-        assert len(result.kwic_list) == 1
-        assert result.kwic_list[0].speech_id == "i-101"
-        assert result.kwic_list[0].node_word == "search"
-
     def test_get_word_trends_result_uses_include_year_filters(self):
         commons = MagicMock()
         commons.get_filter_opts.return_value = {"year": (1970, 1971)}
@@ -378,39 +328,6 @@ class TestToolRouterEndpoints:
         )
         assert [item.year for item in result.wt_list] == [1970, 1971]
         assert result.wt_list[0].count == {"jobb": 5, "skatt": 1}
-
-    def test_get_word_trend_speeches_result_maps_rows(self):
-        commons = MagicMock()
-        commons.get_filter_opts.return_value = {"year": (1980, 1981)}
-        service = MagicMock()
-        service.get_speeches_for_word_trends.return_value = pd.DataFrame(
-            [
-                {
-                    "name": "Alice Andersson",
-                    "year": 1980,
-                    "speech_id": "i-201",
-                    "speech_name": "Prot 1",
-                    "node_word": "jobb",
-                }
-            ]
-        )
-
-        result = asyncio.run(
-            get_word_trend_speeches_result(
-                search="jobb,skatt",
-                commons=commons,
-                word_trends_service=service,
-            )
-        )
-
-        commons.get_filter_opts.assert_called_once_with(include_year=True)
-        service.get_speeches_for_word_trends.assert_called_once_with(
-            ["jobb", "skatt"],
-            {"year": (1980, 1981)},
-        )
-        assert len(result.speech_list) == 1
-        assert result.speech_list[0].speech_id == "i-201"
-        assert result.speech_list[0].node_word == "jobb"
 
     def test_get_word_hits_maps_reversed_hits(self):
         service = MagicMock()
@@ -449,26 +366,6 @@ class TestToolRouterEndpoints:
         )
         assert result == expected
 
-    def test_get_speeches_result_builds_response_model(self):
-        commons = MagicMock()
-        commons.get_filter_opts.return_value = {"speech_id": ["i-301"]}
-        search_service = MagicMock()
-        df = pd.DataFrame([{"speech_id": "i-301"}])
-        search_service.get_speeches.return_value = df
-
-        with patch("api_swedeb.api.v1.endpoints.tool_router.speeches_to_api_model") as mapper:
-            mapper.return_value = SpeechesResult(
-                speech_list=[SpeechesResultItem(speech_id="i-301", party_abbrev="S", speech_name="Prot 2")]  # type: ignore[list-item]
-            )
-            result = asyncio.run(get_speeches_result(commons=commons, search_service=search_service))
-
-        commons.get_filter_opts.assert_called_once_with(True)
-        search_service.get_speeches.assert_called_once_with(selections={"speech_id": ["i-301"]})
-        mapper.assert_called_once_with(df)
-        assert len(result.speech_list) == 1
-        assert result.speech_list[0].speech_id == "i-301"
-        assert result.speech_list[0].party_abbrev == "S"
-
     def test_get_speech_by_id_result_maps_speech_fields(self):
         search_service = MagicMock()
         search_service.get_speech.return_value = Speech(
@@ -486,37 +383,6 @@ class TestToolRouterEndpoints:
         assert result.speech_text == "speech text"
         assert result.page_number == 12
         assert result.speaker_note == "speaker note"
-
-    def test_get_zip_streams_archive_from_speech_ids(self):
-        download_service = MagicMock()
-        download_service.create_stream.return_value = lambda: iter([b"payload"])
-        search_service = MagicMock()
-        search_service.get_speaker_names.return_value = {"i-501": "Alice Andersson", "i-502": "Bob Berg"}
-        search_service.get_speeches_batch.return_value = iter(
-            [
-                ("i-501", Speech({"paragraphs": ["first speech"]})),
-                ("i-502", Speech({"text": "second speech"})),
-            ]
-        )
-
-        response = asyncio.run(
-            get_zip(ids=["i-501", "i-502"], download_service=download_service, search_service=search_service)
-        )
-        body = asyncio.run(_collect_streaming_response(response))
-
-        assert response.media_type == "application/zip"
-        assert response.headers["Content-Disposition"] == "attachment; filename=speeches.zip"
-        assert body == b"payload"
-        download_service.create_stream.assert_called_once()
-
-    def test_get_zip_rejects_empty_ids(self):
-        search_service = MagicMock()
-
-        with pytest.raises(HTTPException) as excinfo:
-            asyncio.run(get_zip(ids=[], search_service=search_service))
-
-        assert excinfo.value.status_code == 400
-        assert excinfo.value.detail == "Speech ids are required"
 
     def test_get_topics_returns_not_implemented_message(self):
         result = asyncio.run(get_topics())

--- a/tests/api_swedeb/api/services/test_corpus_loader.py
+++ b/tests/api_swedeb/api/services/test_corpus_loader.py
@@ -352,7 +352,7 @@ class TestCorpusLoaderAdditionalBranches:
             }
         )
 
-        loader = CorpusLoader(
+        loader: CorpusLoader = CorpusLoader(
             dtm_tag="tag",
             dtm_folder="folder",
             metadata_filename="metadata",
@@ -369,12 +369,12 @@ class TestCorpusLoaderAdditionalBranches:
         captured = capsys.readouterr()
 
         assert result is loader
-        assert loader._CorpusLoader__lazy_document_index.is_initialized
-        assert loader._CorpusLoader__lazy_vectorized_corpus.is_initialized
-        assert loader._CorpusLoader__lazy_person_codecs.is_initialized
-        assert loader._CorpusLoader__lazy_repository.is_initialized
-        assert loader._CorpusLoader__lazy_prebuilt_speech_index.is_initialized
-        assert loader._CorpusLoader__lazy_prebuilt_page_number_index.is_initialized
+        assert loader._CorpusLoader__lazy_document_index.is_initialized  # type: ignore
+        assert loader._CorpusLoader__lazy_vectorized_corpus.is_initialized  # type: ignore
+        assert loader._CorpusLoader__lazy_person_codecs.is_initialized  # type: ignore
+        assert loader._CorpusLoader__lazy_repository.is_initialized  # type: ignore
+        assert loader._CorpusLoader__lazy_prebuilt_speech_index.is_initialized  # type: ignore
+        assert loader._CorpusLoader__lazy_prebuilt_page_number_index.is_initialized  # type: ignore
         assert "decoded_persons" in loader.__dict__
         assert "year_range" in loader.__dict__
 


### PR DESCRIPTION
Enhance the API by adding `--proxy-headers` to the Uvicorn startup command to ensure correct retrieval of the public URL from Nginx. Additionally, address pandas FutureWarnings by updating the `groupby` and `agg` methods in `corpus_loader.py`. Improve test coverage by organizing deprecated endpoint tests into a separate file and adding type annotations to the `CorpusLoader` instance.

Fixes #354