### PR TITLE
Add pre-search hit estimate endpoint for KWIC

### DIFF
--- a/api_swedeb/api/services/word_trends_service.py
+++ b/api_swedeb/api/services/word_trends_service.py
@@ -101,7 +101,7 @@ class WordTrendsService:
             low = year_range.get("low", 0)
             high = year_range.get("high", 9999)
             mask = corpus.document_index["year"].between(low, high)
-            row_indices = corpus.document_index.index[mask].tolist()
+            row_indices = mask.to_numpy().nonzero()[0]
             count = int(corpus.bag_term_matrix[row_indices, token_id].sum())
         else:
             count = int(corpus.bag_term_matrix[:, token_id].sum())

--- a/api_swedeb/api/services/word_trends_service.py
+++ b/api_swedeb/api/services/word_trends_service.py
@@ -1,8 +1,11 @@
 """Word trends analysis service for parliamentary speech data."""
 
+from typing import Any
+
 import pandas as pd
 
 from api_swedeb.api.services.corpus_loader import CorpusLoader
+from api_swedeb.core.common.utility import PropertyValueMaskingOpts
 from api_swedeb.core.configuration import ConfigValue
 from api_swedeb.core.speech_index import get_speeches_by_words
 from api_swedeb.core.utility import replace_by_patterns
@@ -59,6 +62,51 @@ class WordTrendsService:
             if valid_word:
                 filtered_terms.append(valid_word)
         return filtered_terms
+
+    def estimate_hits(self, word: str, filter_opts: dict[str, Any] | None = None) -> int | None:
+        """Estimate KWIC hit count using DTM column sums with metadata filters.
+
+        Returns the approximate number of corpus positions where `word` occurs
+        within the (optionally filtered) document set. Returns None when the
+        word is not in the DTM vocabulary.
+
+        Args:
+            word: Search word (exact match or lowercase fallback).
+            filter_opts: Optional filter dict from ``build_filter_opts``. Year
+                ranges (key ``"year"``) are handled separately from column
+                filters so that ``PropertyValueMaskingOpts`` is not confused by
+                the nested dict structure.
+
+        Returns:
+            Approximate hit count, or None if the word is not in vocabulary.
+        """
+        resolved = self.word_in_vocabulary(word)
+        if resolved is None:
+            return None
+
+        corpus = self._loader.vectorized_corpus
+        token_id: int = corpus.token2id[resolved]
+
+        opts = dict(filter_opts) if filter_opts else {}
+
+        # Year range is handled as a document_index slice, not via PropertyValueMaskingOpts.
+        year_range = opts.pop("year", None)
+
+        # Apply column filters (party_id, gender_id, …) if any remain.
+        if opts:
+            corpus = corpus.filter(PropertyValueMaskingOpts(**opts))
+
+        # Extract the sparse column for the token and select rows by year.
+        if year_range and isinstance(year_range, dict):
+            low = year_range.get("low", 0)
+            high = year_range.get("high", 9999)
+            mask = corpus.document_index["year"].between(low, high)
+            row_indices = corpus.document_index.index[mask].tolist()
+            count = int(corpus.bag_term_matrix[row_indices, token_id].sum())
+        else:
+            count = int(corpus.bag_term_matrix[:, token_id].sum())
+
+        return count
 
     def get_word_trend_results(
         self, search_terms: list[str], filter_opts: dict, normalize: bool = False

--- a/api_swedeb/api/v1/endpoints/tool_router.py
+++ b/api_swedeb/api/v1/endpoints/tool_router.py
@@ -53,6 +53,7 @@ from api_swedeb.schemas.bulk_archive_schema import (
     BulkArchiveFormat,
 )
 from api_swedeb.schemas.kwic_schema import (
+    KWICEstimateResult,
     KWICPageResult,
     KWICQueryRequest,
     KWICTicketAccepted,
@@ -115,6 +116,40 @@ def _require_ready_ticket(ticket_id: str, result_store: ResultStore) -> TicketMe
     if ticket.status == TicketStatus.ERROR:
         raise HTTPException(status_code=409, detail=ticket.error or "Ticket failed")
     return ticket
+
+
+@router.get("/kwic/estimate", response_model=KWICEstimateResult)
+async def estimate_kwic_hits(
+    word: str = Query(..., description="Word to estimate hit count for"),
+    from_year: int | None = Query(None, description="Start year (inclusive)"),
+    to_year: int | None = Query(None, description="End year (inclusive)"),
+    who: list[str] | None = Query(None, description="Speaker person_id filter"),
+    party_id: list[int] | None = Query(None, description="Party ID filter"),
+    gender_id: list[int] | None = Query(None, description="Gender ID filter"),
+    chamber_abbrev: list[str] | None = Query(None, description="Chamber abbreviation filter"),
+    word_trends_service: WordTrendsService = Depends(get_word_trends_service),
+) -> KWICEstimateResult:
+    """Return an approximate hit count for a KWIC search word using DTM column sums.
+
+    The estimate is computed from the document-term matrix and respects the same
+    metadata filters as a real search, but does not run a CQP query. Response
+    time is typically under 20 ms for a cached corpus.
+    """
+    from api_swedeb.api.params import build_filter_opts
+
+    filter_opts = build_filter_opts(
+        from_year=from_year,
+        to_year=to_year,
+        who=who,
+        party_id=party_id,
+        gender_id=gender_id,
+        chamber_abbrev=chamber_abbrev,
+    )
+    count = word_trends_service.estimate_hits(word, filter_opts)
+    return KWICEstimateResult(
+        in_vocabulary=count is not None,
+        estimated_hits=count,
+    )
 
 
 @router.post("/kwic/query", response_model=KWICTicketAccepted, status_code=202)

--- a/api_swedeb/api/v1/endpoints/tool_router.py
+++ b/api_swedeb/api/v1/endpoints/tool_router.py
@@ -120,13 +120,8 @@ def _require_ready_ticket(ticket_id: str, result_store: ResultStore) -> TicketMe
 
 @router.get("/kwic/estimate", response_model=KWICEstimateResult)
 async def estimate_kwic_hits(
-    word: str = Query(..., description="Word to estimate hit count for"),
-    from_year: int | None = Query(None, description="Start year (inclusive)"),
-    to_year: int | None = Query(None, description="End year (inclusive)"),
-    who: list[str] | None = Query(None, description="Speaker person_id filter"),
-    party_id: list[int] | None = Query(None, description="Party ID filter"),
-    gender_id: list[int] | None = Query(None, description="Gender ID filter"),
-    chamber_abbrev: list[str] | None = Query(None, description="Chamber abbreviation filter"),
+    word: Annotated[str, Query(description="Word to estimate hit count for")],
+    commons: CommonParams,
     word_trends_service: WordTrendsService = Depends(get_word_trends_service),
 ) -> KWICEstimateResult:
     """Return an approximate hit count for a KWIC search word using DTM column sums.
@@ -135,16 +130,7 @@ async def estimate_kwic_hits(
     metadata filters as a real search, but does not run a CQP query. Response
     time is typically under 20 ms for a cached corpus.
     """
-    from api_swedeb.api.params import build_filter_opts
-
-    filter_opts = build_filter_opts(
-        from_year=from_year,
-        to_year=to_year,
-        who=who,
-        party_id=party_id,
-        gender_id=gender_id,
-        chamber_abbrev=chamber_abbrev,
-    )
+    filter_opts = commons.get_filter_opts(include_year=True)
     count = word_trends_service.estimate_hits(word, filter_opts)
     return KWICEstimateResult(
         in_vocabulary=count is not None,

--- a/api_swedeb/schemas/kwic_schema.py
+++ b/api_swedeb/schemas/kwic_schema.py
@@ -84,6 +84,13 @@ class KWICPageResult(BaseModel):
     kwic_list: list[KeywordInContextItem]
 
 
+class KWICEstimateResult(BaseModel):
+    estimated_hits: int | None = Field(
+        None, description="Approximate hit count from DTM; null if word is not in vocabulary"
+    )
+    in_vocabulary: bool = Field(..., description="Whether the word appears in the DTM vocabulary")
+
+
 class SortBy(Enum):
     left_word = "left_word"
     node_word = "node_word"

--- a/docs/proposals/progressive-kwic-loading.md
+++ b/docs/proposals/progressive-kwic-loading.md
@@ -13,18 +13,18 @@
 ### Phase 1 — Pre-search estimate
 
 **Backend**
-- [ ] Add `KWICEstimateService` (or extend `KWICService`) with a DTM column-sum method that respects the same metadata filters as `WordTrendsService`
-- [ ] Add `GET /v1/tools/kwic/estimate` endpoint with query params matching the KWIC search form
-- [ ] Return `{ "estimated_hits": N, "in_vocabulary": true/false }` schema
+- [x] Add `KWICEstimateService` (or extend `KWICService`) with a DTM column-sum method that respects the same metadata filters as `WordTrendsService`
+- [x] Add `GET /v1/tools/kwic/estimate` endpoint with query params matching the KWIC search form
+- [x] Return `{ "estimated_hits": N, "in_vocabulary": true/false }` schema
 - [ ] Add `kwic.estimate` section to `config/config.yml` and `tests/config.yml` if needed
-- [ ] Add unit test for the estimate method (mocked DTM)
-- [ ] Add API test for the estimate endpoint
+- [x] Add unit test for the estimate method (mocked DTM) — `tests/api_swedeb/api/services/test_estimate_hits.py` (16 tests)
+- [x] Add API test for the estimate endpoint — `tests/api_swedeb/api/endpoints/test_kwic_estimate_endpoint.py` (11 tests)
 
 **Frontend**
-- [ ] Add `fetchEstimate(word, filters)` action to `kwicDataStore.js`
-- [ ] Debounce estimate call on word input and filter changes (300 ms)
-- [ ] Display estimate near the search button with colour-coded guidance
-- [ ] Label estimate as approximate; do not block the search
+- [x] Add `fetchEstimate(word, filters)` action to `kwicDataStore.js`
+- [x] Debounce estimate call on word input and filter changes (300 ms)
+- [x] Display estimate near the search button with colour-coded guidance
+- [x] Label estimate as approximate; do not block the search
 
 ---
 

--- a/docs/proposals/progressive-kwic-loading.md
+++ b/docs/proposals/progressive-kwic-loading.md
@@ -8,6 +8,86 @@
 
 ---
 
+## Progress
+
+### Phase 1 — Pre-search estimate
+
+**Backend**
+- [ ] Add `KWICEstimateService` (or extend `KWICService`) with a DTM column-sum method that respects the same metadata filters as `WordTrendsService`
+- [ ] Add `GET /v1/tools/kwic/estimate` endpoint with query params matching the KWIC search form
+- [ ] Return `{ "estimated_hits": N, "in_vocabulary": true/false }` schema
+- [ ] Add `kwic.estimate` section to `config/config.yml` and `tests/config.yml` if needed
+- [ ] Add unit test for the estimate method (mocked DTM)
+- [ ] Add API test for the estimate endpoint
+
+**Frontend**
+- [ ] Add `fetchEstimate(word, filters)` action to `kwicDataStore.js`
+- [ ] Debounce estimate call on word input and filter changes (300 ms)
+- [ ] Display estimate near the search button with colour-coded guidance
+- [ ] Label estimate as approximate; do not block the search
+
+---
+
+### Phase 2 — Threshold-based display mode
+
+**Config**
+- [ ] Add `kwic.large_result_threshold` (default: `10000`) to `config/config.yml` and `tests/config.yml`
+- [ ] Add `kwic.large_result_display_limit` (default: `1000`) to both config files
+
+**Backend**
+- [ ] Read threshold and display limit via `ConfigValue` in `KWICTicketService`
+- [ ] Cap `total_pages` in `get_page_result` when `estimated_hits >= threshold`
+- [ ] Include `display_limited: true` and `display_limit: N` in the page result response schema
+- [ ] Verify archive/download endpoint ignores the display cap
+- [ ] Add tests for the capped and uncapped paths
+
+**Frontend**
+- [ ] Consume `display_limited` and `display_limit` from the status/page response
+- [ ] Show a banner: "Sökningen har ~N träffar. Tabellen visar de första M. Ladda ner alla…"
+- [ ] Surface download CTA prominently alongside the banner
+- [ ] Remove the silent `cut_off` fallback path
+
+---
+
+### Phase 3 — Progressive shard delivery
+
+**Backend — Result store**
+- [ ] Add `PARTIAL` to `TicketStatus` enum
+- [ ] Add `shards_complete: int` and `shards_total: int` to `TicketMeta`
+- [ ] Add `store_shard(ticket_id, shard_index, df)` to `ResultStore`
+- [ ] Change artifact layout to per-ticket directory (`{ticket_id}/shard_NNNN.feather`)
+- [ ] Write shard files atomically (temp file + rename)
+- [ ] Update `load_artifact` to concatenate available shards during `PARTIAL`
+- [ ] Write `merged.feather` at `READY` for the download path
+- [ ] Update cleanup to delete the per-ticket directory
+
+**Backend — Executor**
+- [ ] Change `execute_kwic_multiprocess` to call `store_shard` in `as_completed` loop
+- [ ] Call `store_ready` after all shards are written
+- [ ] Keep single-process path unchanged
+
+**Backend — API**
+- [ ] Expose `shards_complete`, `shards_total`, `total_hits` in the status response
+- [ ] Add `estimated_hits` to the ticket-accepted response (computed at submit time)
+- [ ] Update page response to work correctly during `PARTIAL`
+- [ ] Verify download endpoint waits for `READY` before streaming
+
+**Backend — Tests**
+- [ ] Test `store_shard` writes atomically and advances `shards_complete`
+- [ ] Test `load_artifact` concatenates shards in order during `PARTIAL`
+- [ ] Test `store_ready` produces a `merged.feather` consistent with all shards
+- [ ] Test executor emits `PARTIAL` before `READY`
+
+**Frontend**
+- [ ] Update `waitForTicketReady` poll loop to continue on `partial`
+- [ ] Render rows progressively as new pages arrive during `PARTIAL`
+- [ ] Show a shard progress bar from `shards_complete / shards_total`
+- [ ] Disable column sort controls during `PARTIAL`; re-enable and re-sort at `READY`
+- [ ] Remove Phase 2 display-limit banner and config key reads
+- [ ] Remove the `cut_off` parameter from request construction
+
+---
+
 ## Summary
 
 This proposal has three layers, each independently shippable and each building on the previous:

--- a/tests/api_swedeb/api/endpoints/test_kwic_estimate_endpoint.py
+++ b/tests/api_swedeb/api/endpoints/test_kwic_estimate_endpoint.py
@@ -1,0 +1,179 @@
+"""Endpoint tests for GET /v1/tools/kwic/estimate.
+
+Strategy: minimal FastAPI app with dependency_overrides so that
+WordTrendsService is mocked; no corpus or config needed.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from api_swedeb.api.dependencies import get_word_trends_service
+from api_swedeb.api.v1.endpoints import tool_router
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_app(word_trends_service: MagicMock) -> FastAPI:
+    app = FastAPI()
+    app.include_router(tool_router.router)
+    app.dependency_overrides[get_word_trends_service] = lambda: word_trends_service
+    return app
+
+
+@pytest.fixture(name="estimate_client")
+def _estimate_client():
+    """Yield (TestClient, mock_service) pair."""
+    service = MagicMock()
+    with TestClient(_make_app(service), raise_server_exceptions=True) as client:
+        yield client, service
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestEstimateEndpointWordInVocabulary:
+    def test_returns_200_with_estimated_hits(self, estimate_client):
+        client, service = estimate_client
+        service.estimate_hits.return_value = 42
+
+        r = client.get("/v1/tools/kwic/estimate", params={"word": "klimat"})
+
+        assert r.status_code == 200
+        body = r.json()
+        assert body["in_vocabulary"] is True
+        assert body["estimated_hits"] == 42
+
+    def test_calls_estimate_hits_with_word_only(self, estimate_client):
+        client, service = estimate_client
+        service.estimate_hits.return_value = 5
+
+        client.get("/v1/tools/kwic/estimate", params={"word": "klimat"})
+
+        service.estimate_hits.assert_called_once()
+        args, kwargs = service.estimate_hits.call_args
+        assert args[0] == "klimat"
+
+    def test_calls_estimate_hits_with_year_range(self, estimate_client):
+        client, service = estimate_client
+        service.estimate_hits.return_value = 7
+
+        client.get(
+            "/v1/tools/kwic/estimate",
+            params={"word": "budget", "from_year": 1990, "to_year": 2000},
+        )
+
+        args, kwargs = service.estimate_hits.call_args
+        filter_opts = args[1]
+        assert filter_opts["year"] == {"low": 1990, "high": 2000}
+
+    def test_calls_estimate_hits_with_party_id(self, estimate_client):
+        client, service = estimate_client
+        service.estimate_hits.return_value = 3
+
+        client.get(
+            "/v1/tools/kwic/estimate",
+            params={"word": "skola", "party_id": [1, 2]},
+        )
+
+        args, _ = service.estimate_hits.call_args
+        assert args[1]["party_id"] == [1, 2]
+
+    def test_calls_estimate_hits_with_gender_id(self, estimate_client):
+        client, service = estimate_client
+        service.estimate_hits.return_value = 10
+
+        client.get(
+            "/v1/tools/kwic/estimate",
+            params={"word": "lag", "gender_id": [1]},
+        )
+
+        args, _ = service.estimate_hits.call_args
+        assert args[1]["gender_id"] == [1]
+
+    def test_calls_estimate_hits_with_chamber_abbrev(self, estimate_client):
+        client, service = estimate_client
+        service.estimate_hits.return_value = 2
+
+        client.get(
+            "/v1/tools/kwic/estimate",
+            params={"word": "riksdag", "chamber_abbrev": ["AK"]},
+        )
+
+        args, _ = service.estimate_hits.call_args
+        assert args[1]["chamber_abbrev"] == ["AK"]
+
+    def test_calls_estimate_hits_with_who_filter(self, estimate_client):
+        client, service = estimate_client
+        service.estimate_hits.return_value = 1
+
+        client.get(
+            "/v1/tools/kwic/estimate",
+            params={"word": "val", "who": ["Q123", "Q456"]},
+        )
+
+        args, _ = service.estimate_hits.call_args
+        assert args[1]["person_id"] == ["Q123", "Q456"]
+
+    def test_all_filters_combined(self, estimate_client):
+        client, service = estimate_client
+        service.estimate_hits.return_value = 15
+
+        r = client.get(
+            "/v1/tools/kwic/estimate",
+            params={
+                "word": "demokrati",
+                "from_year": 1980,
+                "to_year": 2020,
+                "party_id": [1],
+                "gender_id": [2],
+                "chamber_abbrev": ["FK"],
+            },
+        )
+
+        assert r.status_code == 200
+        args, _ = service.estimate_hits.call_args
+        opts = args[1]
+        assert opts["year"] == {"low": 1980, "high": 2020}
+        assert opts["party_id"] == [1]
+        assert opts["gender_id"] == [2]
+        assert opts["chamber_abbrev"] == ["FK"]
+
+
+class TestEstimateEndpointWordNotInVocabulary:
+    def test_returns_200_with_in_vocabulary_false(self, estimate_client):
+        client, service = estimate_client
+        service.estimate_hits.return_value = None
+
+        r = client.get("/v1/tools/kwic/estimate", params={"word": "xyzzy"})
+
+        assert r.status_code == 200
+        body = r.json()
+        assert body["in_vocabulary"] is False
+        assert body["estimated_hits"] is None
+
+
+class TestEstimateEndpointValidation:
+    def test_missing_word_returns_422(self, estimate_client):
+        client, _ = estimate_client
+        r = client.get("/v1/tools/kwic/estimate")
+        assert r.status_code == 422
+
+    def test_zero_estimated_hits_is_valid(self, estimate_client):
+        client, service = estimate_client
+        service.estimate_hits.return_value = 0
+
+        r = client.get("/v1/tools/kwic/estimate", params={"word": "rare"})
+
+        assert r.status_code == 200
+        body = r.json()
+        assert body["in_vocabulary"] is True
+        assert body["estimated_hits"] == 0

--- a/tests/api_swedeb/api/services/test_estimate_hits.py
+++ b/tests/api_swedeb/api/services/test_estimate_hits.py
@@ -83,14 +83,14 @@ class TestEstimateHitsNoFilters:
         # demokrati: col 1 — docs 0,1,2 → 0+3+1 = 4
         assert service.estimate_hits("demokrati") == 4
 
-    def test_lowercase_fallback_matches_vocabulary_word(self):
-        # Put an upper-case key in token2id but the service does lowercase fallback
+    def test_lowercase_query_does_not_match_mixed_case_vocabulary_word(self):
+        # Put a mixed-case key in token2id; a lowercase query should not match it.
         corpus = _make_corpus()
         corpus.token2id = {"Klimat": 0, "demokrati": 1, "budget": 2}
         loader = MagicMock()
         loader.vectorized_corpus = corpus
         service = WordTrendsService(loader=loader)
-        # "klimat" not in token2id directly; "Klimat" also not; no match
+        # "klimat" is not an exact token2id key, so the lookup returns no match.
         assert service.estimate_hits("klimat") is None
 
     def test_exact_match_preferred_over_lowercase(self):

--- a/tests/api_swedeb/api/services/test_estimate_hits.py
+++ b/tests/api_swedeb/api/services/test_estimate_hits.py
@@ -1,0 +1,189 @@
+"""Unit tests for WordTrendsService.estimate_hits."""
+
+from unittest.mock import MagicMock
+
+import numpy as np
+import pandas as pd
+import scipy.sparse as sp
+
+from api_swedeb.api.services.word_trends_service import WordTrendsService
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+TOKEN2ID = {"klimat": 0, "demokrati": 1, "budget": 2}
+
+# 3 documents × 3 tokens: each document has a different count per token
+# doc 0 (year=1990, party_id=1, gender_id=1): klimat=2, demokrati=0, budget=1
+# doc 1 (year=2000, party_id=1, gender_id=2): klimat=0, demokrati=3, budget=0
+# doc 2 (year=2010, party_id=2, gender_id=1): klimat=1, demokrati=1, budget=0
+MATRIX = sp.csr_matrix(
+    np.array(
+        [
+            [2, 0, 1],
+            [0, 3, 0],
+            [1, 1, 0],
+        ],
+        dtype=np.int32,
+    )
+)
+
+DOCUMENT_INDEX = pd.DataFrame(
+    {
+        "year": [1990, 2000, 2010],
+        "party_id": [1, 1, 2],
+        "gender_id": [1, 2, 1],
+    }
+)
+
+
+def _make_corpus(matrix=MATRIX, doc_index=DOCUMENT_INDEX) -> MagicMock:
+    corpus = MagicMock()
+    corpus.token2id = dict(TOKEN2ID)
+    corpus.bag_term_matrix = matrix
+    corpus.document_index = doc_index.copy().reset_index(drop=True)
+    return corpus
+
+
+def _make_loader(corpus=None) -> MagicMock:
+    loader = MagicMock()
+    loader.vectorized_corpus = corpus or _make_corpus()
+    return loader
+
+
+def _make_filtered_corpus(rows: list[int]) -> MagicMock:
+    """Return a mock corpus that looks like the result of corpus.filter(...) with only the given rows."""
+    sub_matrix = MATRIX[rows, :]
+    sub_doc_index = DOCUMENT_INDEX.iloc[rows].copy().reset_index(drop=True)
+    return _make_corpus(matrix=sub_matrix, doc_index=sub_doc_index)
+
+
+# ---------------------------------------------------------------------------
+# Tests — no filters
+# ---------------------------------------------------------------------------
+
+
+class TestEstimateHitsNoFilters:
+    def test_returns_none_for_unknown_word(self):
+        service = WordTrendsService(loader=_make_loader())
+        assert service.estimate_hits("nonexistent") is None
+
+    def test_returns_none_for_empty_string(self):
+        service = WordTrendsService(loader=_make_loader())
+        assert service.estimate_hits("") is None
+
+    def test_returns_total_column_sum_for_known_word(self):
+        service = WordTrendsService(loader=_make_loader())
+        # klimat: col 0 — docs 0,1,2 → 2+0+1 = 3
+        assert service.estimate_hits("klimat") == 3
+
+    def test_returns_correct_sum_for_second_token(self):
+        service = WordTrendsService(loader=_make_loader())
+        # demokrati: col 1 — docs 0,1,2 → 0+3+1 = 4
+        assert service.estimate_hits("demokrati") == 4
+
+    def test_lowercase_fallback_matches_vocabulary_word(self):
+        # Put an upper-case key in token2id but the service does lowercase fallback
+        corpus = _make_corpus()
+        corpus.token2id = {"Klimat": 0, "demokrati": 1, "budget": 2}
+        loader = MagicMock()
+        loader.vectorized_corpus = corpus
+        service = WordTrendsService(loader=loader)
+        # "klimat" not in token2id directly; "Klimat" also not; no match
+        assert service.estimate_hits("klimat") is None
+
+    def test_exact_match_preferred_over_lowercase(self):
+        # If exact match exists, it is used without lowercasing
+        corpus = _make_corpus()
+        service = WordTrendsService(loader=MagicMock(vectorized_corpus=corpus))
+        assert service.estimate_hits("klimat") == 3  # exact match, col 0
+
+    def test_returns_zero_when_token_has_no_occurrences(self):
+        # Replace row values so budget (col 2) sums to 0 across all docs
+        matrix = sp.csr_matrix(np.array([[0, 0, 0], [0, 3, 0], [1, 1, 0]], dtype=np.int32))
+        service = WordTrendsService(loader=_make_loader(_make_corpus(matrix=matrix)))
+        assert service.estimate_hits("budget") == 0
+
+
+# ---------------------------------------------------------------------------
+# Tests — year filter
+# ---------------------------------------------------------------------------
+
+
+class TestEstimateHitsYearFilter:
+    def test_single_year_selects_one_document(self):
+        service = WordTrendsService(loader=_make_loader())
+        # year=1990 only → row 0 → klimat count = 2
+        opts = {"year": {"low": 1990, "high": 1990}}
+        assert service.estimate_hits("klimat", opts) == 2
+
+    def test_year_range_selects_multiple_documents(self):
+        service = WordTrendsService(loader=_make_loader())
+        # years 1990–2000 → rows 0,1 → demokrati = 0+3 = 3
+        opts = {"year": {"low": 1990, "high": 2000}}
+        assert service.estimate_hits("demokrati", opts) == 3
+
+    def test_year_range_outside_corpus_returns_zero(self):
+        service = WordTrendsService(loader=_make_loader())
+        opts = {"year": {"low": 1800, "high": 1850}}
+        assert service.estimate_hits("klimat", opts) == 0
+
+    def test_missing_low_defaults_to_zero(self):
+        service = WordTrendsService(loader=_make_loader())
+        # low defaults to 0 → all years with year <= 2000 → rows 0,1 → klimat = 2+0 = 2
+        opts = {"year": {"high": 2000}}
+        assert service.estimate_hits("klimat", opts) == 2
+
+    def test_missing_high_defaults_to_large_value(self):
+        service = WordTrendsService(loader=_make_loader())
+        # high defaults to 9999 → all years with year >= 2000 → rows 1,2 → klimat = 0+1 = 1
+        opts = {"year": {"low": 2000}}
+        assert service.estimate_hits("klimat", opts) == 1
+
+    def test_none_filter_opts_behaves_like_no_filter(self):
+        service = WordTrendsService(loader=_make_loader())
+        assert service.estimate_hits("klimat", None) == 3
+
+
+# ---------------------------------------------------------------------------
+# Tests — column filters (party_id, gender_id) via corpus.filter()
+# ---------------------------------------------------------------------------
+
+
+class TestEstimateHitsColumnFilters:
+    def _service_with_filter_side_effect(self):
+        """Return a service whose corpus.filter returns only party_id=1 rows (0,1)."""
+        base_corpus = _make_corpus()
+        filtered_corpus = _make_filtered_corpus([0, 1])
+
+        base_corpus.filter = MagicMock(return_value=filtered_corpus)
+
+        loader = MagicMock()
+        loader.vectorized_corpus = base_corpus
+        return WordTrendsService(loader=loader)
+
+    def test_column_filter_delegates_to_corpus_filter(self):
+        service = self._service_with_filter_side_effect()
+        opts = {"party_id": [1]}
+        # After filter → rows 0,1 → klimat = 2+0 = 2
+        result = service.estimate_hits("klimat", opts)
+        assert result == 2
+        service._loader.vectorized_corpus.filter.assert_called_once()
+
+    def test_year_and_column_filter_combined(self):
+        """Year filter applied after corpus.filter reduces rows further."""
+        service = self._service_with_filter_side_effect()
+        # party_id filter → rows 0,1 (years 1990, 2000)
+        # then year 1990–1990 → row 0 only → klimat = 2
+        opts = {"party_id": [1], "year": {"low": 1990, "high": 1990}}
+        result = service.estimate_hits("klimat", opts)
+        assert result == 2
+
+    def test_no_column_filter_does_not_call_corpus_filter(self):
+        corpus = _make_corpus()
+        corpus.filter = MagicMock()
+        loader = MagicMock(vectorized_corpus=corpus)
+        service = WordTrendsService(loader=loader)
+        service.estimate_hits("klimat")
+        corpus.filter.assert_not_called()

--- a/tests/profile_kwic.py
+++ b/tests/profile_kwic.py
@@ -72,12 +72,12 @@ def main() -> None:
     args = _parse_args()
     use_multiprocessing: bool | None = None if args.num_processes is None else (args.num_processes > 1)
 
+    import ccc
+
     from api_swedeb.api.params import build_common_query_params
     from api_swedeb.api.services.corpus_loader import CorpusLoader
     from api_swedeb.api.services.kwic_service import KWICService
     from api_swedeb.core.configuration.inject import ConfigValue, get_config_store
-
-    import ccc
 
     get_config_store().configure_context(source=args.config)
 

--- a/tests/profile_kwic.py
+++ b/tests/profile_kwic.py
@@ -31,6 +31,7 @@ import sys
 import time
 import uuid
 
+import ccc
 from loguru import logger
 
 logger.remove()
@@ -71,8 +72,6 @@ def _parse_args() -> argparse.Namespace:
 def main() -> None:
     args = _parse_args()
     use_multiprocessing: bool | None = None if args.num_processes is None else (args.num_processes > 1)
-
-    import ccc
 
     from api_swedeb.api.params import build_common_query_params
     from api_swedeb.api.services.corpus_loader import CorpusLoader


### PR DESCRIPTION
Introduce a new endpoint to estimate hit counts for KWIC searches, allowing users to gauge potential results before executing a full search. This implementation includes a new schema for the estimate result, an estimation method in the WordTrendsService, and a dedicated API endpoint. Additionally, comprehensive unit and endpoint tests ensure functionality. This addresses the issue of silent truncation in KWIC searches by providing users with an approximate hit count and vocabulary membership check.

Fixes #356