### PR TITLE
feat(kwic): threshold-based display cap for large result sets

### DIFF
--- a/api_swedeb/api/services/kwic_ticket_service.py
+++ b/api_swedeb/api/services/kwic_ticket_service.py
@@ -356,11 +356,29 @@ class KWICTicketService:
         When *total_hits* is below the configured threshold the result is
         uncapped and the original *total_pages* is returned unchanged.
         """
-        threshold: int = ConfigValue("kwic.large_result_threshold", default=10000).resolve()
+        default_threshold = 10000
+        default_display_limit = 1000
+
+        try:
+            threshold = int(ConfigValue("kwic.large_result_threshold", default=default_threshold).resolve())
+        except (TypeError, ValueError):
+            threshold = default_threshold
+        if threshold <= 0:
+            threshold = default_threshold
+
         if total_hits < threshold:
             return False, None, total_pages
-        display_limit: int = ConfigValue("kwic.large_result_display_limit", default=1000).resolve()
-        capped_pages: int = math.ceil(display_limit / page_size) if display_limit else 0
+
+        try:
+            display_limit = int(
+                ConfigValue("kwic.large_result_display_limit", default=default_display_limit).resolve()
+            )
+        except (TypeError, ValueError):
+            display_limit = default_display_limit
+        if display_limit <= 0:
+            display_limit = default_display_limit
+
+        capped_pages: int = math.ceil(display_limit / page_size)
         return True, display_limit, min(capped_pages, total_pages)
 
     def get_full_artifact(self, ticket_id: str, result_store: ResultStore) -> pd.DataFrame:

--- a/api_swedeb/api/services/kwic_ticket_service.py
+++ b/api_swedeb/api/services/kwic_ticket_service.py
@@ -251,6 +251,7 @@ class KWICTicketService:
 
         total_hits: int = len(data.index)
         total_pages: int = math.ceil(total_hits / page_size) if total_hits else 0
+        display_limited, display_limit, total_pages = self._display_cap(total_hits, total_pages, page_size)
         ticket: TicketMeta | None = result_store.get_ticket(ticket_id)
         expires_at: datetime = ticket.expires_at if ticket is not None else (datetime.now(UTC) + timedelta(seconds=600))
 
@@ -278,6 +279,8 @@ class KWICTicketService:
             page_size=page_size,
             total_hits=total_hits,
             total_pages=total_pages,
+            display_limited=display_limited,
+            display_limit=display_limit,
             expires_at=expires_at,
             kwic_list=kwic_api_frame_to_model(page_frame).kwic_list,
         )
@@ -305,6 +308,7 @@ class KWICTicketService:
         data: pd.DataFrame = result_store.load_artifact(ticket_id)
         total_hits: int = len(data.index)
         total_pages: int = math.ceil(total_hits / page_size) if total_hits else 0
+        display_limited, display_limit, total_pages = self._display_cap(total_hits, total_pages, page_size)
         if total_pages == 0:
             if page != 1:
                 raise ValueError("Requested page is out of range")
@@ -329,6 +333,8 @@ class KWICTicketService:
             page_size=page_size,
             total_hits=total_hits,
             total_pages=total_pages,
+            display_limited=display_limited,
+            display_limit=display_limit,
             expires_at=ticket.expires_at,
             kwic_list=kwic_api_frame_to_model(page_frame).kwic_list,
         )
@@ -343,6 +349,19 @@ class KWICTicketService:
             return (TICKET_ROW_ID,), (True,)
 
         return (sort_by.value, TICKET_ROW_ID), (sort_order == SortOrder.asc, True)
+
+    def _display_cap(self, total_hits: int, total_pages: int, page_size: int) -> tuple[bool, int | None, int]:
+        """Return (display_limited, display_limit, effective_total_pages).
+
+        When *total_hits* is below the configured threshold the result is
+        uncapped and the original *total_pages* is returned unchanged.
+        """
+        threshold: int = ConfigValue("kwic.large_result_threshold", default=10000).resolve()
+        if total_hits < threshold:
+            return False, None, total_pages
+        display_limit: int = ConfigValue("kwic.large_result_display_limit", default=1000).resolve()
+        capped_pages: int = math.ceil(display_limit / page_size) if display_limit else 0
+        return True, display_limit, min(capped_pages, total_pages)
 
     def get_full_artifact(self, ticket_id: str, result_store: ResultStore) -> pd.DataFrame:
         result_store.touch_ticket(ticket_id)

--- a/api_swedeb/schemas/kwic_schema.py
+++ b/api_swedeb/schemas/kwic_schema.py
@@ -80,7 +80,7 @@ class KWICPageResult(BaseModel):
     page_size: int
     total_hits: int
     total_pages: int
-    display_limited: bool = Field(False, description="True when total_hits exceeds the large-result threshold")
+    display_limited: bool = Field(False, description="True when total_hits is at or above the large-result threshold")
     display_limit: int | None = Field(
         None, description="Maximum rows navigable via pagination when display_limited is True"
     )

--- a/api_swedeb/schemas/kwic_schema.py
+++ b/api_swedeb/schemas/kwic_schema.py
@@ -80,6 +80,10 @@ class KWICPageResult(BaseModel):
     page_size: int
     total_hits: int
     total_pages: int
+    display_limited: bool = Field(False, description="True when total_hits exceeds the large-result threshold")
+    display_limit: int | None = Field(
+        None, description="Maximum rows navigable via pagination when display_limited is True"
+    )
     expires_at: datetime
     kwic_list: list[KeywordInContextItem]
 

--- a/config/config.yml
+++ b/config/config.yml
@@ -75,6 +75,8 @@ startup:
 kwic:
   use_multiprocessing: true  # Enabled when the current process may safely spawn child workers
   num_processes: 8
+  large_result_threshold: 10000   # Total hits at or above this value trigger the display cap
+  large_result_display_limit: 1000  # Maximum rows shown in the table when the cap is active
 
 celery:
   broker_url: redis://redis:6379/0

--- a/docs/proposals/progressive-kwic-loading.md
+++ b/docs/proposals/progressive-kwic-loading.md
@@ -31,21 +31,21 @@
 ### Phase 2 — Threshold-based display mode
 
 **Config**
-- [ ] Add `kwic.large_result_threshold` (default: `10000`) to `config/config.yml` and `tests/config.yml`
-- [ ] Add `kwic.large_result_display_limit` (default: `1000`) to both config files
+- [x] Add `kwic.large_result_threshold` (default: `10000`) to `config/config.yml` and `tests/config.yml`
+- [x] Add `kwic.large_result_display_limit` (default: `1000`) to both config files
 
 **Backend**
-- [ ] Read threshold and display limit via `ConfigValue` in `KWICTicketService`
-- [ ] Cap `total_pages` in `get_page_result` when `estimated_hits >= threshold`
-- [ ] Include `display_limited: true` and `display_limit: N` in the page result response schema
-- [ ] Verify archive/download endpoint ignores the display cap
-- [ ] Add tests for the capped and uncapped paths
+- [x] Read threshold and display limit via `ConfigValue` in `KWICTicketService`
+- [x] Cap `total_pages` in `get_page_result` when `total_hits >= threshold`
+- [x] Include `display_limited: true` and `display_limit: N` in the page result response schema
+- [x] Verify archive/download endpoint ignores the display cap
+- [x] Add tests for the capped and uncapped paths
 
 **Frontend**
-- [ ] Consume `display_limited` and `display_limit` from the status/page response
-- [ ] Show a banner: "Sökningen har ~N träffar. Tabellen visar de första M. Ladda ner alla…"
-- [ ] Surface download CTA prominently alongside the banner
-- [ ] Remove the silent `cut_off` fallback path
+- [x] Consume `display_limited` and `display_limit` from the status/page response
+- [x] Show a banner: "Sökningen har ~N träffar. Tabellen visar de första M. Ladda ner alla…"
+- [x] Surface download CTA prominently alongside the banner
+- [x] Remove the silent `cut_off` from `buildKwicTicketPayload`
 
 ---
 

--- a/tests/api_swedeb/api/services/test_kwic_ticket_service.py
+++ b/tests/api_swedeb/api/services/test_kwic_ticket_service.py
@@ -504,3 +504,127 @@ def test_get_status_does_not_advance_ticket_expiry(tmp_path):
         assert after == fixed_expiry
     finally:
         asyncio.run(store.shutdown())
+
+
+def _make_store(tmp_path, *, max_page_size: int = 200) -> ResultStore:
+    return ResultStore(
+        root_dir=tmp_path,
+        result_ttl_seconds=600,
+        cleanup_interval_seconds=0,
+        max_artifact_bytes=1_000_000,
+        max_pending_jobs=10,
+        max_page_size=max_page_size,
+    )
+
+
+def _make_df(n: int) -> pd.DataFrame:
+    return pd.DataFrame(
+        [
+            {
+                "left_word": f"left-{i}",
+                "node_word": "word",
+                "right_word": f"right-{i}",
+                "name": "Alice",
+                "speech_id": f"i-{i}",
+                TICKET_ROW_ID: i,
+            }
+            for i in range(n)
+        ]
+    )
+
+
+def test_display_cap_returns_uncapped_when_below_threshold():
+    """_display_cap must not cap when total_hits < threshold."""
+    service = KWICTicketService()
+    from api_swedeb.core.configuration.inject import ConfigStore
+
+    store = ConfigStore()
+    store.configure_context(
+        source={"kwic": {"large_result_threshold": 10000, "large_result_display_limit": 1000}},
+        env_prefix=None,
+    )
+    with patch("api_swedeb.core.configuration.inject.get_config_store", return_value=store):
+        limited, limit, pages = service._display_cap(total_hits=5, total_pages=1, page_size=10)
+
+    assert limited is False
+    assert limit is None
+    assert pages == 1
+
+
+def test_display_cap_returns_capped_when_at_or_above_threshold():
+    """_display_cap must cap total_pages when total_hits >= threshold."""
+    service = KWICTicketService()
+    from api_swedeb.core.configuration.inject import ConfigStore
+
+    store = ConfigStore()
+    store.configure_context(
+        source={"kwic": {"large_result_threshold": 10000, "large_result_display_limit": 100}},
+        env_prefix=None,
+    )
+    with patch("api_swedeb.core.configuration.inject.get_config_store", return_value=store):
+        limited, limit, pages = service._display_cap(total_hits=15_000, total_pages=1500, page_size=10)
+
+    assert limited is True
+    assert limit == 100
+    assert pages == 10  # ceil(100 / 10)
+
+
+def test_get_page_result_propagates_display_limited_flag(tmp_path):
+    """get_page_result must include display_limited/display_limit from _display_cap."""
+    store = _make_store(tmp_path)
+    service = KWICTicketService()
+
+    asyncio.run(store.startup())
+    try:
+        ticket = store.create_ticket(query_meta={"search": "test"})
+        store.store_ready(ticket.ticket_id, df=_make_df(5))
+
+        with (
+            patch("api_swedeb.api.services.kwic_ticket_service.ConfigValue.resolve", return_value=False),
+            patch.object(service, "_display_cap", return_value=(True, 100, 1)),
+        ):
+            result = service.get_page_result(
+                ticket_id=ticket.ticket_id,
+                result_store=store,
+                page=1,
+                page_size=10,
+                sort_by=None,
+                sort_order=SortOrder.asc,
+            )
+
+        assert isinstance(result, KWICPageResult)
+        assert result.display_limited is True
+        assert result.display_limit == 100
+        assert result.total_pages == 1
+    finally:
+        asyncio.run(store.shutdown())
+
+
+def test_get_page_result_propagates_uncapped_flag(tmp_path):
+    """get_page_result must pass display_limited=False through when not capped."""
+    store = _make_store(tmp_path)
+    service = KWICTicketService()
+
+    asyncio.run(store.startup())
+    try:
+        ticket = store.create_ticket(query_meta={"search": "test"})
+        store.store_ready(ticket.ticket_id, df=_make_df(5))
+
+        with (
+            patch("api_swedeb.api.services.kwic_ticket_service.ConfigValue.resolve", return_value=False),
+            patch.object(service, "_display_cap", return_value=(False, None, 1)),
+        ):
+            result = service.get_page_result(
+                ticket_id=ticket.ticket_id,
+                result_store=store,
+                page=1,
+                page_size=10,
+                sort_by=None,
+                sort_order=SortOrder.asc,
+            )
+
+        assert isinstance(result, KWICPageResult)
+        assert result.display_limited is False
+        assert result.display_limit is None
+    finally:
+        asyncio.run(store.shutdown())

--- a/tests/config.yml
+++ b/tests/config.yml
@@ -35,6 +35,8 @@ startup:
 kwic:
   use_multiprocessing: true
   num_processes: 8
+  large_result_threshold: 10000
+  large_result_display_limit: 1000
 
 celery:
   broker_url: redis://redis:6379/0


### PR DESCRIPTION
Add server-side display cap (Phase 2 of progressive KWIC loading):
- Add large_result_threshold and large_result_display_limit to config
- Add _display_cap() to KWICTicketService; apply in local and Celery paths
- Extend KWICPageResult with display_limited and display_limit fields
- Archive/download path unaffected by cap
- Add 4 unit tests for capped and uncapped paths

Closes #358