### PR TITLE
Add pre-search hit estimate endpoint and threshold-based display cap for KWIC

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,9 @@ workflow-logs:
 	@gh run list --workflow staging.yml --branch staging --limit 1
 	@gh run view --web
 
+staging-deploy:
+	@./manage-target staging deploy
+
 staging-api-logs:
 	@./manage-target staging podman logs swedeb-api-staging
 

--- a/Makefile
+++ b/Makefile
@@ -120,13 +120,18 @@ profile-utils-pyinstrument: build-utils
 	@uv run pyinstrument tests/profiling/profile_utilities.py
 
 TIMESTAMP_IN_ISO_FORMAT=$(shell date -u +"%Y%m%dT%H%M%SZ")
-
+NUM_PROCESSES ?= 1
 profile-kwic-pyinstrument:
 	@echo "Profiling KWIC..."
 	@mkdir -p tests/output
 	@PYTHONPATH=. pyinstrument --color --show-all \
 		-o tests/output/$(TIMESTAMP_IN_ISO_FORMAT)_profile_kwic.html \
-			tests/profile_kwic.py
+			tests/profile_kwic.py \
+			--word och \
+			--words-before 5 \
+			--words-after 5 \
+			--cut-off 200000 \
+			--num-processes $(NUM_PROCESSES)
 
 # Benchmark: singleprocess vs. multiprocess KWIC on the full corpus.
 # Override defaults via env vars, e.g.:
@@ -151,7 +156,7 @@ benchmark-kwic:
 profile-zip-pyinstrument:
 	@echo "Profiling create_zip_stream(1970-1975)..."
 	@mkdir -p tests/output
-	@PYTHONPATH=. uv run pyinstrument --color --show-all \
+	@PYTHONPATH=. uv run pyinstrument --color --show-all --num-processes $(NUM_PROCESSES) \
 		-o tests/output/$(TIMESTAMP_IN_ISO_FORMAT)_profile_zip_stream.html \
 			tests/profiling/profile_zip_stream.py
 

--- a/api_swedeb/api/services/kwic_service.py
+++ b/api_swedeb/api/services/kwic_service.py
@@ -57,6 +57,8 @@ class KWICService:
             words_after: Number of words after search term(s)
             p_show: What to display ("word" or "lemma")
             cut_off: Maximum number of hits to return
+            use_multiprocessing: Whether to use multiprocessing (overrides config if not None)
+            n_processes: Number of processes for multiprocessing (overrides config if not None)
 
         Returns:
             DataFrame with KWIC data

--- a/api_swedeb/api/services/kwic_ticket_service.py
+++ b/api_swedeb/api/services/kwic_ticket_service.py
@@ -356,11 +356,29 @@ class KWICTicketService:
         When *total_hits* is below the configured threshold the result is
         uncapped and the original *total_pages* is returned unchanged.
         """
-        threshold: int = ConfigValue("kwic.large_result_threshold", default=10000).resolve()
+        default_threshold = 10000
+        default_display_limit = 1000
+
+        try:
+            threshold = int(ConfigValue("kwic.large_result_threshold", default=default_threshold).resolve())
+        except (TypeError, ValueError):
+            threshold = default_threshold
+        if threshold <= 0:
+            threshold = default_threshold
+
         if total_hits < threshold:
             return False, None, total_pages
-        display_limit: int = ConfigValue("kwic.large_result_display_limit", default=1000).resolve()
-        capped_pages: int = math.ceil(display_limit / page_size) if display_limit else 0
+
+        try:
+            display_limit = int(
+                ConfigValue("kwic.large_result_display_limit", default=default_display_limit).resolve()
+            )
+        except (TypeError, ValueError):
+            display_limit = default_display_limit
+        if display_limit <= 0:
+            display_limit = default_display_limit
+
+        capped_pages: int = math.ceil(display_limit / page_size)
         return True, display_limit, min(capped_pages, total_pages)
 
     def get_full_artifact(self, ticket_id: str, result_store: ResultStore) -> pd.DataFrame:

--- a/api_swedeb/api/services/kwic_ticket_service.py
+++ b/api_swedeb/api/services/kwic_ticket_service.py
@@ -251,6 +251,7 @@ class KWICTicketService:
 
         total_hits: int = len(data.index)
         total_pages: int = math.ceil(total_hits / page_size) if total_hits else 0
+        display_limited, display_limit, total_pages = self._display_cap(total_hits, total_pages, page_size)
         ticket: TicketMeta | None = result_store.get_ticket(ticket_id)
         expires_at: datetime = ticket.expires_at if ticket is not None else (datetime.now(UTC) + timedelta(seconds=600))
 
@@ -278,6 +279,8 @@ class KWICTicketService:
             page_size=page_size,
             total_hits=total_hits,
             total_pages=total_pages,
+            display_limited=display_limited,
+            display_limit=display_limit,
             expires_at=expires_at,
             kwic_list=kwic_api_frame_to_model(page_frame).kwic_list,
         )
@@ -305,6 +308,7 @@ class KWICTicketService:
         data: pd.DataFrame = result_store.load_artifact(ticket_id)
         total_hits: int = len(data.index)
         total_pages: int = math.ceil(total_hits / page_size) if total_hits else 0
+        display_limited, display_limit, total_pages = self._display_cap(total_hits, total_pages, page_size)
         if total_pages == 0:
             if page != 1:
                 raise ValueError("Requested page is out of range")
@@ -329,6 +333,8 @@ class KWICTicketService:
             page_size=page_size,
             total_hits=total_hits,
             total_pages=total_pages,
+            display_limited=display_limited,
+            display_limit=display_limit,
             expires_at=ticket.expires_at,
             kwic_list=kwic_api_frame_to_model(page_frame).kwic_list,
         )
@@ -343,6 +349,19 @@ class KWICTicketService:
             return (TICKET_ROW_ID,), (True,)
 
         return (sort_by.value, TICKET_ROW_ID), (sort_order == SortOrder.asc, True)
+
+    def _display_cap(self, total_hits: int, total_pages: int, page_size: int) -> tuple[bool, int | None, int]:
+        """Return (display_limited, display_limit, effective_total_pages).
+
+        When *total_hits* is below the configured threshold the result is
+        uncapped and the original *total_pages* is returned unchanged.
+        """
+        threshold: int = ConfigValue("kwic.large_result_threshold", default=10000).resolve()
+        if total_hits < threshold:
+            return False, None, total_pages
+        display_limit: int = ConfigValue("kwic.large_result_display_limit", default=1000).resolve()
+        capped_pages: int = math.ceil(display_limit / page_size) if display_limit else 0
+        return True, display_limit, min(capped_pages, total_pages)
 
     def get_full_artifact(self, ticket_id: str, result_store: ResultStore) -> pd.DataFrame:
         result_store.touch_ticket(ticket_id)

--- a/api_swedeb/api/services/word_trends_service.py
+++ b/api_swedeb/api/services/word_trends_service.py
@@ -101,7 +101,7 @@ class WordTrendsService:
             low = year_range.get("low", 0)
             high = year_range.get("high", 9999)
             mask = corpus.document_index["year"].between(low, high)
-            row_indices = corpus.document_index.index[mask].tolist()
+            row_indices = mask.to_numpy().nonzero()[0]
             count = int(corpus.bag_term_matrix[row_indices, token_id].sum())
         else:
             count = int(corpus.bag_term_matrix[:, token_id].sum())

--- a/api_swedeb/api/services/word_trends_service.py
+++ b/api_swedeb/api/services/word_trends_service.py
@@ -1,8 +1,11 @@
 """Word trends analysis service for parliamentary speech data."""
 
+from typing import Any
+
 import pandas as pd
 
 from api_swedeb.api.services.corpus_loader import CorpusLoader
+from api_swedeb.core.common.utility import PropertyValueMaskingOpts
 from api_swedeb.core.configuration import ConfigValue
 from api_swedeb.core.speech_index import get_speeches_by_words
 from api_swedeb.core.utility import replace_by_patterns
@@ -59,6 +62,51 @@ class WordTrendsService:
             if valid_word:
                 filtered_terms.append(valid_word)
         return filtered_terms
+
+    def estimate_hits(self, word: str, filter_opts: dict[str, Any] | None = None) -> int | None:
+        """Estimate KWIC hit count using DTM column sums with metadata filters.
+
+        Returns the approximate number of corpus positions where `word` occurs
+        within the (optionally filtered) document set. Returns None when the
+        word is not in the DTM vocabulary.
+
+        Args:
+            word: Search word (exact match or lowercase fallback).
+            filter_opts: Optional filter dict from ``build_filter_opts``. Year
+                ranges (key ``"year"``) are handled separately from column
+                filters so that ``PropertyValueMaskingOpts`` is not confused by
+                the nested dict structure.
+
+        Returns:
+            Approximate hit count, or None if the word is not in vocabulary.
+        """
+        resolved = self.word_in_vocabulary(word)
+        if resolved is None:
+            return None
+
+        corpus = self._loader.vectorized_corpus
+        token_id: int = corpus.token2id[resolved]
+
+        opts = dict(filter_opts) if filter_opts else {}
+
+        # Year range is handled as a document_index slice, not via PropertyValueMaskingOpts.
+        year_range = opts.pop("year", None)
+
+        # Apply column filters (party_id, gender_id, …) if any remain.
+        if opts:
+            corpus = corpus.filter(PropertyValueMaskingOpts(**opts))
+
+        # Extract the sparse column for the token and select rows by year.
+        if year_range and isinstance(year_range, dict):
+            low = year_range.get("low", 0)
+            high = year_range.get("high", 9999)
+            mask = corpus.document_index["year"].between(low, high)
+            row_indices = corpus.document_index.index[mask].tolist()
+            count = int(corpus.bag_term_matrix[row_indices, token_id].sum())
+        else:
+            count = int(corpus.bag_term_matrix[:, token_id].sum())
+
+        return count
 
     def get_word_trend_results(
         self, search_terms: list[str], filter_opts: dict, normalize: bool = False

--- a/api_swedeb/api/v1/endpoints/tool_router.py
+++ b/api_swedeb/api/v1/endpoints/tool_router.py
@@ -53,6 +53,7 @@ from api_swedeb.schemas.bulk_archive_schema import (
     BulkArchiveFormat,
 )
 from api_swedeb.schemas.kwic_schema import (
+    KWICEstimateResult,
     KWICPageResult,
     KWICQueryRequest,
     KWICTicketAccepted,
@@ -115,6 +116,40 @@ def _require_ready_ticket(ticket_id: str, result_store: ResultStore) -> TicketMe
     if ticket.status == TicketStatus.ERROR:
         raise HTTPException(status_code=409, detail=ticket.error or "Ticket failed")
     return ticket
+
+
+@router.get("/kwic/estimate", response_model=KWICEstimateResult)
+async def estimate_kwic_hits(
+    word: str = Query(..., description="Word to estimate hit count for"),
+    from_year: int | None = Query(None, description="Start year (inclusive)"),
+    to_year: int | None = Query(None, description="End year (inclusive)"),
+    who: list[str] | None = Query(None, description="Speaker person_id filter"),
+    party_id: list[int] | None = Query(None, description="Party ID filter"),
+    gender_id: list[int] | None = Query(None, description="Gender ID filter"),
+    chamber_abbrev: list[str] | None = Query(None, description="Chamber abbreviation filter"),
+    word_trends_service: WordTrendsService = Depends(get_word_trends_service),
+) -> KWICEstimateResult:
+    """Return an approximate hit count for a KWIC search word using DTM column sums.
+
+    The estimate is computed from the document-term matrix and respects the same
+    metadata filters as a real search, but does not run a CQP query. Response
+    time is typically under 20 ms for a cached corpus.
+    """
+    from api_swedeb.api.params import build_filter_opts
+
+    filter_opts = build_filter_opts(
+        from_year=from_year,
+        to_year=to_year,
+        who=who,
+        party_id=party_id,
+        gender_id=gender_id,
+        chamber_abbrev=chamber_abbrev,
+    )
+    count = word_trends_service.estimate_hits(word, filter_opts)
+    return KWICEstimateResult(
+        in_vocabulary=count is not None,
+        estimated_hits=count,
+    )
 
 
 @router.post("/kwic/query", response_model=KWICTicketAccepted, status_code=202)

--- a/api_swedeb/api/v1/endpoints/tool_router.py
+++ b/api_swedeb/api/v1/endpoints/tool_router.py
@@ -120,13 +120,8 @@ def _require_ready_ticket(ticket_id: str, result_store: ResultStore) -> TicketMe
 
 @router.get("/kwic/estimate", response_model=KWICEstimateResult)
 async def estimate_kwic_hits(
-    word: str = Query(..., description="Word to estimate hit count for"),
-    from_year: int | None = Query(None, description="Start year (inclusive)"),
-    to_year: int | None = Query(None, description="End year (inclusive)"),
-    who: list[str] | None = Query(None, description="Speaker person_id filter"),
-    party_id: list[int] | None = Query(None, description="Party ID filter"),
-    gender_id: list[int] | None = Query(None, description="Gender ID filter"),
-    chamber_abbrev: list[str] | None = Query(None, description="Chamber abbreviation filter"),
+    word: Annotated[str, Query(description="Word to estimate hit count for")],
+    commons: CommonParams,
     word_trends_service: WordTrendsService = Depends(get_word_trends_service),
 ) -> KWICEstimateResult:
     """Return an approximate hit count for a KWIC search word using DTM column sums.
@@ -135,16 +130,7 @@ async def estimate_kwic_hits(
     metadata filters as a real search, but does not run a CQP query. Response
     time is typically under 20 ms for a cached corpus.
     """
-    from api_swedeb.api.params import build_filter_opts
-
-    filter_opts = build_filter_opts(
-        from_year=from_year,
-        to_year=to_year,
-        who=who,
-        party_id=party_id,
-        gender_id=gender_id,
-        chamber_abbrev=chamber_abbrev,
-    )
+    filter_opts = commons.get_filter_opts(include_year=True)
     count = word_trends_service.estimate_hits(word, filter_opts)
     return KWICEstimateResult(
         in_vocabulary=count is not None,

--- a/api_swedeb/core/kwic/patches.py
+++ b/api_swedeb/core/kwic/patches.py
@@ -15,13 +15,18 @@ B2 – Cache.get / Cache.set → no-ops
     path — pure overhead that is never recouped.  Patching both get and set
     to no-ops eliminates this cost without changing observable results.
 
-B5 – Corpus.dump2patt → hoist PosAttrib handle
+B5 – Corpus.dump2patt → hoisted PosAttrib handle + vectorized row loop
     The original ``_dump2patt_row`` calls
     ``self.attributes.attribute(p_att, 'p')`` on every row through
     ``df.apply``.  For the kwic format, dump2patt is called three times
     (left context, node, right context), so for a 500 k-row result this
-    creates 1.5 M redundant C-extension attribute handles.  The replacement
-    hoists the single handle creation outside the row loop.
+    creates 1.5 M redundant C-extension attribute handles.
+
+    This replacement additionally eliminates the ``df.apply(axis=1)`` call,
+    which constructs a full pandas Series object per row.  Instead, the two
+    position columns are extracted as plain Python lists and iterated with a
+    list comprehension, which avoids per-row Series allocation while keeping
+    the same CWB ``p[start:end+1]`` slice semantics.
 """
 
 from __future__ import annotations
@@ -59,8 +64,10 @@ def _noop_cache_set(self, identifier, value):  # noqa: ARG001
 def _patched_dump2patt(self, df_dump, p_att="word", start="match", end="matchend"):
     """Retrieve p-attribute annotation from start to end.
 
-    Drop-in replacement for Corpus.dump2patt that hoists the PosAttrib
-    handle outside the per-row apply loop.
+    Drop-in replacement for Corpus.dump2patt that:
+    - Hoists the PosAttrib handle outside the row loop (was: one per row).
+    - Replaces df.apply(axis=1) with a list comprehension over plain Python
+      lists, avoiding the per-row pandas Series allocation.
     """
     index_names = df_dump.index.names
     df = df_dump.reset_index()
@@ -68,9 +75,12 @@ def _patched_dump2patt(self, df_dump, p_att="word", start="match", end="matchend
     # One handle for the whole column — not one per row.
     p = self.attributes.attribute(p_att, "p")
 
-    def _row(row):
-        cpos_start = row.get(start, -1)
-        cpos_end = row.get(end, -1)
+    # Extract position columns as Python lists to avoid per-row Series
+    # construction that df.apply(axis=1) would impose.
+    starts = df[start].tolist() if start in df.columns else [-1] * len(df)
+    ends = df[end].tolist() if end in df.columns else [-1] * len(df)
+
+    def _get_tokens(cpos_start, cpos_end):
         if cpos_start == cpos_end == -1:
             return ""
         if cpos_start == -1:
@@ -79,7 +89,7 @@ def _patched_dump2patt(self, df_dump, p_att="word", start="match", end="matchend
             cpos_end = cpos_start
         return " ".join(p[int(cpos_start) : int(cpos_end) + 1])
 
-    df[p_att] = df.apply(_row, axis=1)
+    df[p_att] = [_get_tokens(s, e) for s, e in zip(starts, ends)]
     return df.set_index(index_names)
 
 

--- a/api_swedeb/core/load.py
+++ b/api_swedeb/core/load.py
@@ -77,7 +77,7 @@ def _memory_usage(document_index: pd.DataFrame) -> float:
 def is_invalidated(source_path: str, target_path: str) -> bool:
     if not isfile(target_path):
         return True
-    logger.info(f"Source: {os.path.getmtime(source_path)}, Target: {os.path.getmtime(target_path)}")
+    # logger.info(f"Source: {os.path.getmtime(source_path)}, Target: {os.path.getmtime(target_path)}")
     return os.path.getmtime(source_path) > os.path.getmtime(target_path)
 
 

--- a/api_swedeb/schemas/kwic_schema.py
+++ b/api_swedeb/schemas/kwic_schema.py
@@ -80,7 +80,7 @@ class KWICPageResult(BaseModel):
     page_size: int
     total_hits: int
     total_pages: int
-    display_limited: bool = Field(False, description="True when total_hits exceeds the large-result threshold")
+    display_limited: bool = Field(False, description="True when total_hits is at or above the large-result threshold")
     display_limit: int | None = Field(
         None, description="Maximum rows navigable via pagination when display_limited is True"
     )

--- a/api_swedeb/schemas/kwic_schema.py
+++ b/api_swedeb/schemas/kwic_schema.py
@@ -84,6 +84,13 @@ class KWICPageResult(BaseModel):
     kwic_list: list[KeywordInContextItem]
 
 
+class KWICEstimateResult(BaseModel):
+    estimated_hits: int | None = Field(
+        None, description="Approximate hit count from DTM; null if word is not in vocabulary"
+    )
+    in_vocabulary: bool = Field(..., description="Whether the word appears in the DTM vocabulary")
+
+
 class SortBy(Enum):
     left_word = "left_word"
     node_word = "node_word"

--- a/api_swedeb/schemas/kwic_schema.py
+++ b/api_swedeb/schemas/kwic_schema.py
@@ -80,6 +80,10 @@ class KWICPageResult(BaseModel):
     page_size: int
     total_hits: int
     total_pages: int
+    display_limited: bool = Field(False, description="True when total_hits exceeds the large-result threshold")
+    display_limit: int | None = Field(
+        None, description="Maximum rows navigable via pagination when display_limited is True"
+    )
     expires_at: datetime
     kwic_list: list[KeywordInContextItem]
 

--- a/config/config.yml
+++ b/config/config.yml
@@ -75,6 +75,8 @@ startup:
 kwic:
   use_multiprocessing: true  # Enabled when the current process may safely spawn child workers
   num_processes: 8
+  large_result_threshold: 10000   # Total hits at or above this value trigger the display cap
+  large_result_display_limit: 1000  # Maximum rows shown in the table when the cap is active
 
 celery:
   broker_url: redis://redis:6379/0

--- a/config/config.yml
+++ b/config/config.yml
@@ -55,7 +55,7 @@ metadata:
     path: data
 
 cwb:
-  registry_dir: /data/registry
+  registry_dir: ./data/v1.4.1/registry
   corpus_name: RIKSPROT_CORPUS
 
 dtm:

--- a/docs/proposals/progressive-kwic-loading.md
+++ b/docs/proposals/progressive-kwic-loading.md
@@ -13,18 +13,18 @@
 ### Phase 1 — Pre-search estimate
 
 **Backend**
-- [ ] Add `KWICEstimateService` (or extend `KWICService`) with a DTM column-sum method that respects the same metadata filters as `WordTrendsService`
-- [ ] Add `GET /v1/tools/kwic/estimate` endpoint with query params matching the KWIC search form
-- [ ] Return `{ "estimated_hits": N, "in_vocabulary": true/false }` schema
+- [x] Add `KWICEstimateService` (or extend `KWICService`) with a DTM column-sum method that respects the same metadata filters as `WordTrendsService`
+- [x] Add `GET /v1/tools/kwic/estimate` endpoint with query params matching the KWIC search form
+- [x] Return `{ "estimated_hits": N, "in_vocabulary": true/false }` schema
 - [ ] Add `kwic.estimate` section to `config/config.yml` and `tests/config.yml` if needed
-- [ ] Add unit test for the estimate method (mocked DTM)
-- [ ] Add API test for the estimate endpoint
+- [x] Add unit test for the estimate method (mocked DTM) — `tests/api_swedeb/api/services/test_estimate_hits.py` (16 tests)
+- [x] Add API test for the estimate endpoint — `tests/api_swedeb/api/endpoints/test_kwic_estimate_endpoint.py` (11 tests)
 
 **Frontend**
-- [ ] Add `fetchEstimate(word, filters)` action to `kwicDataStore.js`
-- [ ] Debounce estimate call on word input and filter changes (300 ms)
-- [ ] Display estimate near the search button with colour-coded guidance
-- [ ] Label estimate as approximate; do not block the search
+- [x] Add `fetchEstimate(word, filters)` action to `kwicDataStore.js`
+- [x] Debounce estimate call on word input and filter changes (300 ms)
+- [x] Display estimate near the search button with colour-coded guidance
+- [x] Label estimate as approximate; do not block the search
 
 ---
 

--- a/docs/proposals/progressive-kwic-loading.md
+++ b/docs/proposals/progressive-kwic-loading.md
@@ -1,0 +1,309 @@
+# Progressive KWIC Loading
+
+## Status
+
+- Proposed feature
+- Scope: backend (result store, ticket service, multiprocess executor, new estimate endpoint) + frontend (KWIC store, table display)
+- Goal: give users hit-count estimates before searching, apply threshold-based display limits transparently, and deliver KWIC results incrementally as corpus shards complete — removing the silent hard cut-off for both display and download
+
+---
+
+## Summary
+
+This proposal has three layers, each independently shippable and each building on the previous:
+
+1. **Pre-search estimate** — a cheap DTM-based count shown to the user before they press "Sök", setting expectations without touching the search path.
+2. **Threshold-based display mode** — when the estimate exceeds a configured limit, the table shows a bounded sample and prominently surfaces download instead of silently cutting off. Replaces the invisible `cut_off`.
+3. **Progressive shard delivery** — results appear in the table as each year-range shard finishes, removing the wait entirely for large queries.
+
+All three share a single new estimate endpoint and the same `estimated_hits` field in the ticket-accepted response.
+
+---
+
+## Problem
+
+KWIC searches for common words or unfiltered queries can return hundreds of thousands of hits. The current options are:
+
+1. Apply `cut_off` — users never see the full result set, and the truncation is invisible.
+2. Remove `cut_off` — the server blocks for 60+ seconds before returning anything.
+
+Users who want complete data have no good option. Users who get a truncated result often don't know it. The ticket-and-poll architecture is already in place; what is missing is pre-search awareness and shard-level visibility.
+
+---
+
+## Scope
+
+**Phase 1 — Pre-search estimate**
+- New `GET /v1/tools/kwic/estimate` endpoint returning a DTM-based hit count for a word + filter combination.
+- Frontend: debounced estimate call as the user types or changes filters; display result near the search button with colour-coded guidance.
+
+**Phase 2 — Threshold-based display mode**
+- When `estimated_hits` exceeds a configured threshold, the ticket pipeline serves a bounded sample (e.g. first N rows from the first available shard) and prominently surfaces the download path.
+- The threshold and sample size are config-driven, not hardcoded.
+- The silent `cut_off` parameter is retired; behaviour is now explicit and communicated to the user.
+
+**Phase 3 — Progressive shard delivery**
+- Add a `PARTIAL` ticket status that exposes completed shards for paging before the full query finishes.
+- Store results per shard rather than as a single artifact file.
+- Add `shards_complete` / `shards_total` to the ticket status response for progress display.
+- Remove the display limit from Phase 2; the table grows as shards arrive.
+- Frontend: adapt the KWIC poll loop to render rows during `PARTIAL`, show a progress indicator, and disable sort controls until `READY`.
+
+---
+
+## Non-Goals
+
+- Sub-shard streaming (CQP is monolithic per shard; row-level streaming is not feasible).
+- Progressive loading for n-grams (the DTM path is already fast; no benefit).
+- Sorting across partial result sets (sort is applied per shard during `PARTIAL`; global sort activates at `READY`).
+- Changing the shard boundary strategy (year-range sharding already implemented in the multiprocess path).
+
+---
+
+## Current Behavior
+
+`KWICTicketService.execute_ticket` calls `kwic_service.get_kwic(...)` which either runs single-process (for small queries) or spawns N worker processes via `execute_kwic_multiprocess`. In both cases results are fully assembled before `result_store.store_ready(...)` is called. The client polls status until `READY`, then fetches pages from a single feather artifact. `cut_off` is passed through to cap the CQP dump before processing. Truncation is silent — the user sees no indication that results were cut.
+
+---
+
+## Proposed Design
+
+### Phase 1: Pre-search estimate endpoint
+
+**New endpoint**
+
+```
+GET /v1/tools/kwic/estimate?word=och&lemmatized=false&from_year=1900&party=S&...
+```
+
+Response:
+```json
+{ "estimated_hits": 47000, "in_vocabulary": true }
+```
+
+The backend does a single DTM column sum with the same filter opts used by `WordTrendsService`. No CQP query is run. Response time target: < 20 ms. If the word is not in the vocabulary or uses wildcards that cannot be resolved to a single token, `in_vocabulary` is `false` and `estimated_hits` is `null`.
+
+`WordTrendsService` already has access to the filtered DTM via `get_word_trend_results`; the estimate endpoint adds a lightweight method that returns only the total column sum without building time-series data.
+
+**Frontend display**
+
+The KWIC search form makes a debounced estimate call (300 ms delay) whenever the search word or any filter changes. The result appears near the search button:
+
+| Estimated hits | Display |
+|---|---|
+| `null` / `in_vocabulary: false` | No indicator (word not in DTM, exact count only from CQP) |
+| < threshold | "~N träffar förväntade" (neutral) |
+| ≥ threshold | "~N träffar — stor träffmängd, nedladdning rekommenderas" (amber) |
+
+The estimate is always labelled as approximate. It does not block the search.
+
+### Phase 2: Threshold-based display mode
+
+A new config key `kwic.large_result_threshold` (default: `10000`) controls when the display mode changes.
+
+When `estimated_hits >= threshold`:
+
+- The ticket pipeline runs as normal but the **results endpoint caps the returned page range** to the first `kwic.large_result_display_limit` rows (default: `1000`, config-driven).
+- The status response includes `display_limited: true` and `display_limit: 1000`.
+- The frontend shows a prominent banner: *"Sökningen har ~47 000 träffar. Tabellen visar de första 1 000. Ladda ner alla träffar via nedladdningsknappen."*
+- The download path is unchanged — it returns all rows regardless of the display limit.
+
+This replaces the current silent `cut_off`. The user sees exactly what is happening and has a clear path to the full data set.
+
+**Implementation note**: the display cap is applied in `KWICTicketService.get_page_result` by capping `total_pages` in the response, not by discarding rows from the artifact. The full artifact is always written so the download path is unaffected.
+
+### Phase 3: Progressive shard delivery
+
+#### Ticket status
+
+Add `PARTIAL` to `TicketStatus`:
+
+```python
+class TicketStatus(StrEnum):
+    PENDING = "pending"
+    PARTIAL = "partial"   # new: some shards done, more in flight
+    READY   = "ready"
+    ERROR   = "error"
+```
+
+`TicketMeta` gains two new fields:
+
+```python
+shards_complete: int = 0
+shards_total: int = 0
+```
+
+#### Shard artifact layout
+
+Replace the single `{cache_dir}/{ticket_id}.feather` file with a per-ticket directory:
+
+```
+{cache_dir}/{ticket_id}/
+    shard_0000.feather     ← written atomically when shard 0 finishes
+    shard_0001.feather
+    ...
+    merged.feather         ← written at READY; used for download
+```
+
+Each shard file is written atomically (write to a `.tmp` sibling, then `rename`). Page requests scan available shard files in index order without acquiring a lock on the full set.
+
+#### Result store changes
+
+- `store_shard(ticket_id, shard_index, df)` — writes a shard file and advances `shards_complete`; transitions status to `PARTIAL`.
+- `store_ready(ticket_id)` — merges shards, writes `merged.feather`, transitions to `READY`.
+- `load_artifact(ticket_id)` — during `PARTIAL`, reads and concatenates available shard files; during `READY`, reads `merged.feather`.
+- `artifact_path` returns the directory; callers that use it directly need updating.
+- Cleanup deletes the whole per-ticket directory.
+
+#### Multiprocess executor changes
+
+`execute_kwic_multiprocess` currently collects all `Future` results with `as_completed` and concatenates at the end. Change it to call `result_store.store_shard(...)` inside the `as_completed` loop as each shard finishes, then call `result_store.store_ready(...)` after all are done.
+
+Single-process execution remains unchanged (one shard = whole corpus, no `PARTIAL` phase). The Phase 2 display limit is retired once Phase 3 ships; the table simply grows as shards arrive.
+
+#### API changes
+
+`GET /kwic/status/{ticket_id}` response gains:
+
+```json
+{
+  "status": "partial",
+  "shards_complete": 3,
+  "shards_total": 8,
+  "total_hits": 18400
+}
+```
+
+`total_hits` during `PARTIAL` reflects rows available so far.
+
+`POST /kwic/query` accepted response gains `estimated_hits` (reused from the estimate endpoint, computed at query-submit time):
+
+```json
+{ "ticket_id": "...", "estimated_hits": 47000 }
+```
+
+#### Download path
+
+`GET /kwic/download/{ticket_id}` waits for `READY` and streams `merged.feather` with no cut-off. The archive path (`/kwic/archive/{ticket_id}`) is unchanged.
+
+#### Frontend changes (Phase 3)
+
+- Poll loop: continue polling when status is `partial`; stop on `ready` or `error`.
+- Render table rows from each page response during `PARTIAL`.
+- Show a progress bar from `shards_complete / shards_total`.
+- Disable column sort controls during `PARTIAL`; re-enable and re-sort at `READY`.
+- Remove Phase 2 display-limit banner once `PARTIAL` is in production.
+
+---
+
+## Alternatives Considered
+
+**Keep cut_off, add a separate no-cut-off download endpoint.** Simpler to implement but creates two divergent code paths and still gives users no feedback while the full query runs.
+
+**Server-sent events / WebSockets.** Avoids client polling but requires infrastructure changes (SSE or WS support) and complicates the Celery path. The existing poll loop already works; reuse it.
+
+---
+
+## Risks and Tradeoffs
+
+| Risk | Mitigation |
+|---|---|
+| Shard file writes race with page reads | Atomic rename before exposing shard; page reader scans only fully written files |
+| Celery workers write to different filesystems than the API | Already a constraint on the current path; shard files share the same `cache_dir` as the current artifact |
+| `merged.feather` write duplicates disk usage briefly | Acceptable; it is removed along with shards at TTL expiry |
+| Sort accuracy during `PARTIAL` | Documented UX limitation; sort disabled until `READY` |
+| `estimated_hits` is inaccurate for lemmatized queries | Show as "~N expected" not as an exact count; null if word not in vocabulary |
+| Single-process path gains no UX benefit | Acceptable; single-process is used only for small / filtered queries where latency is already low |
+
+---
+
+## Testing and Validation
+
+- Unit tests: `store_shard` writes correctly; page reads during `PARTIAL` return consistent rows; `store_ready` merges and transitions status.
+- Integration test: submit a query known to use multiprocessing; assert `PARTIAL` status appears before `READY`; assert page results accumulate across polls.
+- Manual smoke test: search for "och" with no filters; confirm table rows appear within ~10 s and progress bar advances to 100%.
+- Regression: existing single-process queries reach `READY` without passing through `PARTIAL`.
+
+---
+
+## Acceptance Criteria
+
+1. `TicketStatus.PARTIAL` is a valid status returned by the status endpoint.
+2. Page results are served correctly during `PARTIAL`.
+3. `shards_complete` / `shards_total` are present and accurate in status responses.
+4. `estimated_hits` is returned in the accepted response for words in the vocabulary.
+5. Download waits for `READY` and returns all rows with no cut-off.
+6. Frontend progress bar advances as shards complete; sort controls re-enable at `READY`.
+7. All existing KWIC tests pass.
+8. Shard files and merged artifact are removed at TTL expiry.
+
+---
+
+## Recommended Delivery Order
+
+1. **Phase 1 — Estimate endpoint** (fastest to ship, standalone value)
+   - New `GET /v1/tools/kwic/estimate` endpoint backed by DTM column sums.
+   - Frontend: debounced estimate display near search button with colour-coded guidance.
+   - Zero impact on the ticket pipeline; ships independently.
+
+2. **Phase 2 — Threshold-based display mode** (replaces silent cut_off, safe interim)
+   - Add `kwic.large_result_threshold` and `kwic.large_result_display_limit` config keys.
+   - Apply page cap in `KWICTicketService.get_page_result` when estimate exceeds threshold.
+   - Frontend: display-limit banner + prominent download CTA.
+   - No shard infrastructure required; works with the current single-artifact result store.
+
+3. **Phase 3 — Progressive shard delivery** (completes the architecture)
+   - `TicketStatus.PARTIAL` + `TicketMeta` shard fields + `store_shard` in `ResultStore`.
+   - Shard artifact layout and page reader changes.
+   - `execute_kwic_multiprocess` calls `store_shard` per shard.
+   - API status and schema changes (`shards_complete`, `shards_total`, `total_hits`).
+   - Frontend poll loop during `PARTIAL`, progress bar, sort gating.
+   - `merged.feather` + download path validation.
+   - Retires the Phase 2 display cap once deployed.
+
+---
+
+## Acceptance Criteria
+
+### Phase 1
+- `GET /v1/tools/kwic/estimate?word=X&...` returns `{ "estimated_hits": N, "in_vocabulary": true/false }` within 20 ms for a cached corpus.
+- Returns `{ "estimated_hits": null, "in_vocabulary": false }` for words not in the DTM vocabulary.
+- Frontend shows an estimate near the search button while the user edits parameters.
+- Estimate is labelled as approximate; it does not prevent the search.
+
+### Phase 2
+- When `estimated_hits >= kwic.large_result_threshold`, the table shows at most `kwic.large_result_display_limit` rows.
+- Status response includes `display_limited: true` and `display_limit: N`.
+- A banner explains the limit and points to the download button.
+- Archive/download endpoint still returns all rows regardless of the display limit.
+- Both threshold and display limit are read from config without a code change.
+
+### Phase 3
+- After Phase 3 is deployed, the Phase 2 display cap is retired.
+- `PARTIAL` status is returned while at least one shard is still in flight.
+- Clients can page through available rows during `PARTIAL`.
+- `shards_complete` and `shards_total` are accurate in every status response.
+- At `READY`, `merged.feather` is consistent with the concatenation of all shards.
+- Shard files are cleaned up when the ticket expires or is explicitly deleted.
+- Sort controls are disabled during `PARTIAL` and re-enabled at `READY`.
+
+---
+
+## Final Recommendation
+
+Implement the three phases in order. The backend infrastructure (multiprocess sharding, ticket polling, feather storage) is already in place; each phase extends it incrementally without a separate code path.
+
+Start with Phase 1 (estimate endpoint) to give users immediate visibility into query size. Ship Phase 2 to replace the silent `cut_off` with an explicit, user-facing limit. Then deliver Phase 3 to remove the display limit entirely once the shard model is proven.
+
+---
+
+## Risks and Tradeoffs
+
+| Risk | Severity | Notes |
+|---|---|---|
+| DTM estimate inaccurate for filtered queries | Low | Column sums respect metadata filters; phrase/proximity queries may diverge, but order-of-magnitude accuracy is sufficient for UX guidance |
+| Threshold causes confusion if estimate is wrong | Low | Banner labels estimate as approximate; user can still submit and download |
+| Shard race condition: page read while shard write in flight | Medium | Mitigated by atomic rename before updating `shards_complete`; no partial reads possible |
+| `merged.feather` write doubles disk use briefly | Low | Temporary; shard files deleted after merge |
+| Phase 2 display cap needs explicit removal when Phase 3 ships | Low | Remove banner code path and config keys at deployment |
+| Config key `kwic.large_result_threshold` absent on older deployments | Low | Default value of `10000` provided; no migration required |

--- a/docs/proposals/progressive-kwic-loading.md
+++ b/docs/proposals/progressive-kwic-loading.md
@@ -31,21 +31,21 @@
 ### Phase 2 — Threshold-based display mode
 
 **Config**
-- [ ] Add `kwic.large_result_threshold` (default: `10000`) to `config/config.yml` and `tests/config.yml`
-- [ ] Add `kwic.large_result_display_limit` (default: `1000`) to both config files
+- [x] Add `kwic.large_result_threshold` (default: `10000`) to `config/config.yml` and `tests/config.yml`
+- [x] Add `kwic.large_result_display_limit` (default: `1000`) to both config files
 
 **Backend**
-- [ ] Read threshold and display limit via `ConfigValue` in `KWICTicketService`
-- [ ] Cap `total_pages` in `get_page_result` when `estimated_hits >= threshold`
-- [ ] Include `display_limited: true` and `display_limit: N` in the page result response schema
-- [ ] Verify archive/download endpoint ignores the display cap
-- [ ] Add tests for the capped and uncapped paths
+- [x] Read threshold and display limit via `ConfigValue` in `KWICTicketService`
+- [x] Cap `total_pages` in `get_page_result` when `total_hits >= threshold`
+- [x] Include `display_limited: true` and `display_limit: N` in the page result response schema
+- [x] Verify archive/download endpoint ignores the display cap
+- [x] Add tests for the capped and uncapped paths
 
 **Frontend**
-- [ ] Consume `display_limited` and `display_limit` from the status/page response
-- [ ] Show a banner: "Sökningen har ~N träffar. Tabellen visar de första M. Ladda ner alla…"
-- [ ] Surface download CTA prominently alongside the banner
-- [ ] Remove the silent `cut_off` fallback path
+- [x] Consume `display_limited` and `display_limit` from the status/page response
+- [x] Show a banner: "Sökningen har ~N träffar. Tabellen visar de första M. Ladda ner alla…"
+- [x] Surface download CTA prominently alongside the banner
+- [x] Remove the silent `cut_off` from `buildKwicTicketPayload`
 
 ---
 

--- a/docs/proposals/progressive-kwic-loading.md
+++ b/docs/proposals/progressive-kwic-loading.md
@@ -8,6 +8,86 @@
 
 ---
 
+## Progress
+
+### Phase 1 — Pre-search estimate
+
+**Backend**
+- [ ] Add `KWICEstimateService` (or extend `KWICService`) with a DTM column-sum method that respects the same metadata filters as `WordTrendsService`
+- [ ] Add `GET /v1/tools/kwic/estimate` endpoint with query params matching the KWIC search form
+- [ ] Return `{ "estimated_hits": N, "in_vocabulary": true/false }` schema
+- [ ] Add `kwic.estimate` section to `config/config.yml` and `tests/config.yml` if needed
+- [ ] Add unit test for the estimate method (mocked DTM)
+- [ ] Add API test for the estimate endpoint
+
+**Frontend**
+- [ ] Add `fetchEstimate(word, filters)` action to `kwicDataStore.js`
+- [ ] Debounce estimate call on word input and filter changes (300 ms)
+- [ ] Display estimate near the search button with colour-coded guidance
+- [ ] Label estimate as approximate; do not block the search
+
+---
+
+### Phase 2 — Threshold-based display mode
+
+**Config**
+- [ ] Add `kwic.large_result_threshold` (default: `10000`) to `config/config.yml` and `tests/config.yml`
+- [ ] Add `kwic.large_result_display_limit` (default: `1000`) to both config files
+
+**Backend**
+- [ ] Read threshold and display limit via `ConfigValue` in `KWICTicketService`
+- [ ] Cap `total_pages` in `get_page_result` when `estimated_hits >= threshold`
+- [ ] Include `display_limited: true` and `display_limit: N` in the page result response schema
+- [ ] Verify archive/download endpoint ignores the display cap
+- [ ] Add tests for the capped and uncapped paths
+
+**Frontend**
+- [ ] Consume `display_limited` and `display_limit` from the status/page response
+- [ ] Show a banner: "Sökningen har ~N träffar. Tabellen visar de första M. Ladda ner alla…"
+- [ ] Surface download CTA prominently alongside the banner
+- [ ] Remove the silent `cut_off` fallback path
+
+---
+
+### Phase 3 — Progressive shard delivery
+
+**Backend — Result store**
+- [ ] Add `PARTIAL` to `TicketStatus` enum
+- [ ] Add `shards_complete: int` and `shards_total: int` to `TicketMeta`
+- [ ] Add `store_shard(ticket_id, shard_index, df)` to `ResultStore`
+- [ ] Change artifact layout to per-ticket directory (`{ticket_id}/shard_NNNN.feather`)
+- [ ] Write shard files atomically (temp file + rename)
+- [ ] Update `load_artifact` to concatenate available shards during `PARTIAL`
+- [ ] Write `merged.feather` at `READY` for the download path
+- [ ] Update cleanup to delete the per-ticket directory
+
+**Backend — Executor**
+- [ ] Change `execute_kwic_multiprocess` to call `store_shard` in `as_completed` loop
+- [ ] Call `store_ready` after all shards are written
+- [ ] Keep single-process path unchanged
+
+**Backend — API**
+- [ ] Expose `shards_complete`, `shards_total`, `total_hits` in the status response
+- [ ] Add `estimated_hits` to the ticket-accepted response (computed at submit time)
+- [ ] Update page response to work correctly during `PARTIAL`
+- [ ] Verify download endpoint waits for `READY` before streaming
+
+**Backend — Tests**
+- [ ] Test `store_shard` writes atomically and advances `shards_complete`
+- [ ] Test `load_artifact` concatenates shards in order during `PARTIAL`
+- [ ] Test `store_ready` produces a `merged.feather` consistent with all shards
+- [ ] Test executor emits `PARTIAL` before `READY`
+
+**Frontend**
+- [ ] Update `waitForTicketReady` poll loop to continue on `partial`
+- [ ] Render rows progressively as new pages arrive during `PARTIAL`
+- [ ] Show a shard progress bar from `shards_complete / shards_total`
+- [ ] Disable column sort controls during `PARTIAL`; re-enable and re-sort at `READY`
+- [ ] Remove Phase 2 display-limit banner and config key reads
+- [ ] Remove the `cut_off` parameter from request construction
+
+---
+
 ## Summary
 
 This proposal has three layers, each independently shippable and each building on the previous:

--- a/tests/api_swedeb/api/endpoints/test_kwic_estimate_endpoint.py
+++ b/tests/api_swedeb/api/endpoints/test_kwic_estimate_endpoint.py
@@ -1,0 +1,179 @@
+"""Endpoint tests for GET /v1/tools/kwic/estimate.
+
+Strategy: minimal FastAPI app with dependency_overrides so that
+WordTrendsService is mocked; no corpus or config needed.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from api_swedeb.api.dependencies import get_word_trends_service
+from api_swedeb.api.v1.endpoints import tool_router
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_app(word_trends_service: MagicMock) -> FastAPI:
+    app = FastAPI()
+    app.include_router(tool_router.router)
+    app.dependency_overrides[get_word_trends_service] = lambda: word_trends_service
+    return app
+
+
+@pytest.fixture(name="estimate_client")
+def _estimate_client():
+    """Yield (TestClient, mock_service) pair."""
+    service = MagicMock()
+    with TestClient(_make_app(service), raise_server_exceptions=True) as client:
+        yield client, service
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestEstimateEndpointWordInVocabulary:
+    def test_returns_200_with_estimated_hits(self, estimate_client):
+        client, service = estimate_client
+        service.estimate_hits.return_value = 42
+
+        r = client.get("/v1/tools/kwic/estimate", params={"word": "klimat"})
+
+        assert r.status_code == 200
+        body = r.json()
+        assert body["in_vocabulary"] is True
+        assert body["estimated_hits"] == 42
+
+    def test_calls_estimate_hits_with_word_only(self, estimate_client):
+        client, service = estimate_client
+        service.estimate_hits.return_value = 5
+
+        client.get("/v1/tools/kwic/estimate", params={"word": "klimat"})
+
+        service.estimate_hits.assert_called_once()
+        args, kwargs = service.estimate_hits.call_args
+        assert args[0] == "klimat"
+
+    def test_calls_estimate_hits_with_year_range(self, estimate_client):
+        client, service = estimate_client
+        service.estimate_hits.return_value = 7
+
+        client.get(
+            "/v1/tools/kwic/estimate",
+            params={"word": "budget", "from_year": 1990, "to_year": 2000},
+        )
+
+        args, kwargs = service.estimate_hits.call_args
+        filter_opts = args[1]
+        assert filter_opts["year"] == {"low": 1990, "high": 2000}
+
+    def test_calls_estimate_hits_with_party_id(self, estimate_client):
+        client, service = estimate_client
+        service.estimate_hits.return_value = 3
+
+        client.get(
+            "/v1/tools/kwic/estimate",
+            params={"word": "skola", "party_id": [1, 2]},
+        )
+
+        args, _ = service.estimate_hits.call_args
+        assert args[1]["party_id"] == [1, 2]
+
+    def test_calls_estimate_hits_with_gender_id(self, estimate_client):
+        client, service = estimate_client
+        service.estimate_hits.return_value = 10
+
+        client.get(
+            "/v1/tools/kwic/estimate",
+            params={"word": "lag", "gender_id": [1]},
+        )
+
+        args, _ = service.estimate_hits.call_args
+        assert args[1]["gender_id"] == [1]
+
+    def test_calls_estimate_hits_with_chamber_abbrev(self, estimate_client):
+        client, service = estimate_client
+        service.estimate_hits.return_value = 2
+
+        client.get(
+            "/v1/tools/kwic/estimate",
+            params={"word": "riksdag", "chamber_abbrev": ["AK"]},
+        )
+
+        args, _ = service.estimate_hits.call_args
+        assert args[1]["chamber_abbrev"] == ["AK"]
+
+    def test_calls_estimate_hits_with_who_filter(self, estimate_client):
+        client, service = estimate_client
+        service.estimate_hits.return_value = 1
+
+        client.get(
+            "/v1/tools/kwic/estimate",
+            params={"word": "val", "who": ["Q123", "Q456"]},
+        )
+
+        args, _ = service.estimate_hits.call_args
+        assert args[1]["person_id"] == ["Q123", "Q456"]
+
+    def test_all_filters_combined(self, estimate_client):
+        client, service = estimate_client
+        service.estimate_hits.return_value = 15
+
+        r = client.get(
+            "/v1/tools/kwic/estimate",
+            params={
+                "word": "demokrati",
+                "from_year": 1980,
+                "to_year": 2020,
+                "party_id": [1],
+                "gender_id": [2],
+                "chamber_abbrev": ["FK"],
+            },
+        )
+
+        assert r.status_code == 200
+        args, _ = service.estimate_hits.call_args
+        opts = args[1]
+        assert opts["year"] == {"low": 1980, "high": 2020}
+        assert opts["party_id"] == [1]
+        assert opts["gender_id"] == [2]
+        assert opts["chamber_abbrev"] == ["FK"]
+
+
+class TestEstimateEndpointWordNotInVocabulary:
+    def test_returns_200_with_in_vocabulary_false(self, estimate_client):
+        client, service = estimate_client
+        service.estimate_hits.return_value = None
+
+        r = client.get("/v1/tools/kwic/estimate", params={"word": "xyzzy"})
+
+        assert r.status_code == 200
+        body = r.json()
+        assert body["in_vocabulary"] is False
+        assert body["estimated_hits"] is None
+
+
+class TestEstimateEndpointValidation:
+    def test_missing_word_returns_422(self, estimate_client):
+        client, _ = estimate_client
+        r = client.get("/v1/tools/kwic/estimate")
+        assert r.status_code == 422
+
+    def test_zero_estimated_hits_is_valid(self, estimate_client):
+        client, service = estimate_client
+        service.estimate_hits.return_value = 0
+
+        r = client.get("/v1/tools/kwic/estimate", params={"word": "rare"})
+
+        assert r.status_code == 200
+        body = r.json()
+        assert body["in_vocabulary"] is True
+        assert body["estimated_hits"] == 0

--- a/tests/api_swedeb/api/services/test_estimate_hits.py
+++ b/tests/api_swedeb/api/services/test_estimate_hits.py
@@ -83,14 +83,14 @@ class TestEstimateHitsNoFilters:
         # demokrati: col 1 — docs 0,1,2 → 0+3+1 = 4
         assert service.estimate_hits("demokrati") == 4
 
-    def test_lowercase_fallback_matches_vocabulary_word(self):
-        # Put an upper-case key in token2id but the service does lowercase fallback
+    def test_lowercase_query_does_not_match_mixed_case_vocabulary_word(self):
+        # Put a mixed-case key in token2id; a lowercase query should not match it.
         corpus = _make_corpus()
         corpus.token2id = {"Klimat": 0, "demokrati": 1, "budget": 2}
         loader = MagicMock()
         loader.vectorized_corpus = corpus
         service = WordTrendsService(loader=loader)
-        # "klimat" not in token2id directly; "Klimat" also not; no match
+        # "klimat" is not an exact token2id key, so the lookup returns no match.
         assert service.estimate_hits("klimat") is None
 
     def test_exact_match_preferred_over_lowercase(self):

--- a/tests/api_swedeb/api/services/test_estimate_hits.py
+++ b/tests/api_swedeb/api/services/test_estimate_hits.py
@@ -1,0 +1,189 @@
+"""Unit tests for WordTrendsService.estimate_hits."""
+
+from unittest.mock import MagicMock
+
+import numpy as np
+import pandas as pd
+import scipy.sparse as sp
+
+from api_swedeb.api.services.word_trends_service import WordTrendsService
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+TOKEN2ID = {"klimat": 0, "demokrati": 1, "budget": 2}
+
+# 3 documents × 3 tokens: each document has a different count per token
+# doc 0 (year=1990, party_id=1, gender_id=1): klimat=2, demokrati=0, budget=1
+# doc 1 (year=2000, party_id=1, gender_id=2): klimat=0, demokrati=3, budget=0
+# doc 2 (year=2010, party_id=2, gender_id=1): klimat=1, demokrati=1, budget=0
+MATRIX = sp.csr_matrix(
+    np.array(
+        [
+            [2, 0, 1],
+            [0, 3, 0],
+            [1, 1, 0],
+        ],
+        dtype=np.int32,
+    )
+)
+
+DOCUMENT_INDEX = pd.DataFrame(
+    {
+        "year": [1990, 2000, 2010],
+        "party_id": [1, 1, 2],
+        "gender_id": [1, 2, 1],
+    }
+)
+
+
+def _make_corpus(matrix=MATRIX, doc_index=DOCUMENT_INDEX) -> MagicMock:
+    corpus = MagicMock()
+    corpus.token2id = dict(TOKEN2ID)
+    corpus.bag_term_matrix = matrix
+    corpus.document_index = doc_index.copy().reset_index(drop=True)
+    return corpus
+
+
+def _make_loader(corpus=None) -> MagicMock:
+    loader = MagicMock()
+    loader.vectorized_corpus = corpus or _make_corpus()
+    return loader
+
+
+def _make_filtered_corpus(rows: list[int]) -> MagicMock:
+    """Return a mock corpus that looks like the result of corpus.filter(...) with only the given rows."""
+    sub_matrix = MATRIX[rows, :]
+    sub_doc_index = DOCUMENT_INDEX.iloc[rows].copy().reset_index(drop=True)
+    return _make_corpus(matrix=sub_matrix, doc_index=sub_doc_index)
+
+
+# ---------------------------------------------------------------------------
+# Tests — no filters
+# ---------------------------------------------------------------------------
+
+
+class TestEstimateHitsNoFilters:
+    def test_returns_none_for_unknown_word(self):
+        service = WordTrendsService(loader=_make_loader())
+        assert service.estimate_hits("nonexistent") is None
+
+    def test_returns_none_for_empty_string(self):
+        service = WordTrendsService(loader=_make_loader())
+        assert service.estimate_hits("") is None
+
+    def test_returns_total_column_sum_for_known_word(self):
+        service = WordTrendsService(loader=_make_loader())
+        # klimat: col 0 — docs 0,1,2 → 2+0+1 = 3
+        assert service.estimate_hits("klimat") == 3
+
+    def test_returns_correct_sum_for_second_token(self):
+        service = WordTrendsService(loader=_make_loader())
+        # demokrati: col 1 — docs 0,1,2 → 0+3+1 = 4
+        assert service.estimate_hits("demokrati") == 4
+
+    def test_lowercase_fallback_matches_vocabulary_word(self):
+        # Put an upper-case key in token2id but the service does lowercase fallback
+        corpus = _make_corpus()
+        corpus.token2id = {"Klimat": 0, "demokrati": 1, "budget": 2}
+        loader = MagicMock()
+        loader.vectorized_corpus = corpus
+        service = WordTrendsService(loader=loader)
+        # "klimat" not in token2id directly; "Klimat" also not; no match
+        assert service.estimate_hits("klimat") is None
+
+    def test_exact_match_preferred_over_lowercase(self):
+        # If exact match exists, it is used without lowercasing
+        corpus = _make_corpus()
+        service = WordTrendsService(loader=MagicMock(vectorized_corpus=corpus))
+        assert service.estimate_hits("klimat") == 3  # exact match, col 0
+
+    def test_returns_zero_when_token_has_no_occurrences(self):
+        # Replace row values so budget (col 2) sums to 0 across all docs
+        matrix = sp.csr_matrix(np.array([[0, 0, 0], [0, 3, 0], [1, 1, 0]], dtype=np.int32))
+        service = WordTrendsService(loader=_make_loader(_make_corpus(matrix=matrix)))
+        assert service.estimate_hits("budget") == 0
+
+
+# ---------------------------------------------------------------------------
+# Tests — year filter
+# ---------------------------------------------------------------------------
+
+
+class TestEstimateHitsYearFilter:
+    def test_single_year_selects_one_document(self):
+        service = WordTrendsService(loader=_make_loader())
+        # year=1990 only → row 0 → klimat count = 2
+        opts = {"year": {"low": 1990, "high": 1990}}
+        assert service.estimate_hits("klimat", opts) == 2
+
+    def test_year_range_selects_multiple_documents(self):
+        service = WordTrendsService(loader=_make_loader())
+        # years 1990–2000 → rows 0,1 → demokrati = 0+3 = 3
+        opts = {"year": {"low": 1990, "high": 2000}}
+        assert service.estimate_hits("demokrati", opts) == 3
+
+    def test_year_range_outside_corpus_returns_zero(self):
+        service = WordTrendsService(loader=_make_loader())
+        opts = {"year": {"low": 1800, "high": 1850}}
+        assert service.estimate_hits("klimat", opts) == 0
+
+    def test_missing_low_defaults_to_zero(self):
+        service = WordTrendsService(loader=_make_loader())
+        # low defaults to 0 → all years with year <= 2000 → rows 0,1 → klimat = 2+0 = 2
+        opts = {"year": {"high": 2000}}
+        assert service.estimate_hits("klimat", opts) == 2
+
+    def test_missing_high_defaults_to_large_value(self):
+        service = WordTrendsService(loader=_make_loader())
+        # high defaults to 9999 → all years with year >= 2000 → rows 1,2 → klimat = 0+1 = 1
+        opts = {"year": {"low": 2000}}
+        assert service.estimate_hits("klimat", opts) == 1
+
+    def test_none_filter_opts_behaves_like_no_filter(self):
+        service = WordTrendsService(loader=_make_loader())
+        assert service.estimate_hits("klimat", None) == 3
+
+
+# ---------------------------------------------------------------------------
+# Tests — column filters (party_id, gender_id) via corpus.filter()
+# ---------------------------------------------------------------------------
+
+
+class TestEstimateHitsColumnFilters:
+    def _service_with_filter_side_effect(self):
+        """Return a service whose corpus.filter returns only party_id=1 rows (0,1)."""
+        base_corpus = _make_corpus()
+        filtered_corpus = _make_filtered_corpus([0, 1])
+
+        base_corpus.filter = MagicMock(return_value=filtered_corpus)
+
+        loader = MagicMock()
+        loader.vectorized_corpus = base_corpus
+        return WordTrendsService(loader=loader)
+
+    def test_column_filter_delegates_to_corpus_filter(self):
+        service = self._service_with_filter_side_effect()
+        opts = {"party_id": [1]}
+        # After filter → rows 0,1 → klimat = 2+0 = 2
+        result = service.estimate_hits("klimat", opts)
+        assert result == 2
+        service._loader.vectorized_corpus.filter.assert_called_once()
+
+    def test_year_and_column_filter_combined(self):
+        """Year filter applied after corpus.filter reduces rows further."""
+        service = self._service_with_filter_side_effect()
+        # party_id filter → rows 0,1 (years 1990, 2000)
+        # then year 1990–1990 → row 0 only → klimat = 2
+        opts = {"party_id": [1], "year": {"low": 1990, "high": 1990}}
+        result = service.estimate_hits("klimat", opts)
+        assert result == 2
+
+    def test_no_column_filter_does_not_call_corpus_filter(self):
+        corpus = _make_corpus()
+        corpus.filter = MagicMock()
+        loader = MagicMock(vectorized_corpus=corpus)
+        service = WordTrendsService(loader=loader)
+        service.estimate_hits("klimat")
+        corpus.filter.assert_not_called()

--- a/tests/api_swedeb/api/services/test_kwic_ticket_service.py
+++ b/tests/api_swedeb/api/services/test_kwic_ticket_service.py
@@ -504,3 +504,127 @@ def test_get_status_does_not_advance_ticket_expiry(tmp_path):
         assert after == fixed_expiry
     finally:
         asyncio.run(store.shutdown())
+
+
+def _make_store(tmp_path, *, max_page_size: int = 200) -> ResultStore:
+    return ResultStore(
+        root_dir=tmp_path,
+        result_ttl_seconds=600,
+        cleanup_interval_seconds=0,
+        max_artifact_bytes=1_000_000,
+        max_pending_jobs=10,
+        max_page_size=max_page_size,
+    )
+
+
+def _make_df(n: int) -> pd.DataFrame:
+    return pd.DataFrame(
+        [
+            {
+                "left_word": f"left-{i}",
+                "node_word": "word",
+                "right_word": f"right-{i}",
+                "name": "Alice",
+                "speech_id": f"i-{i}",
+                TICKET_ROW_ID: i,
+            }
+            for i in range(n)
+        ]
+    )
+
+
+def test_display_cap_returns_uncapped_when_below_threshold():
+    """_display_cap must not cap when total_hits < threshold."""
+    service = KWICTicketService()
+    from api_swedeb.core.configuration.inject import ConfigStore
+
+    store = ConfigStore()
+    store.configure_context(
+        source={"kwic": {"large_result_threshold": 10000, "large_result_display_limit": 1000}},
+        env_prefix=None,
+    )
+    with patch("api_swedeb.core.configuration.inject.get_config_store", return_value=store):
+        limited, limit, pages = service._display_cap(total_hits=5, total_pages=1, page_size=10)
+
+    assert limited is False
+    assert limit is None
+    assert pages == 1
+
+
+def test_display_cap_returns_capped_when_at_or_above_threshold():
+    """_display_cap must cap total_pages when total_hits >= threshold."""
+    service = KWICTicketService()
+    from api_swedeb.core.configuration.inject import ConfigStore
+
+    store = ConfigStore()
+    store.configure_context(
+        source={"kwic": {"large_result_threshold": 10000, "large_result_display_limit": 100}},
+        env_prefix=None,
+    )
+    with patch("api_swedeb.core.configuration.inject.get_config_store", return_value=store):
+        limited, limit, pages = service._display_cap(total_hits=15_000, total_pages=1500, page_size=10)
+
+    assert limited is True
+    assert limit == 100
+    assert pages == 10  # ceil(100 / 10)
+
+
+def test_get_page_result_propagates_display_limited_flag(tmp_path):
+    """get_page_result must include display_limited/display_limit from _display_cap."""
+    store = _make_store(tmp_path)
+    service = KWICTicketService()
+
+    asyncio.run(store.startup())
+    try:
+        ticket = store.create_ticket(query_meta={"search": "test"})
+        store.store_ready(ticket.ticket_id, df=_make_df(5))
+
+        with (
+            patch("api_swedeb.api.services.kwic_ticket_service.ConfigValue.resolve", return_value=False),
+            patch.object(service, "_display_cap", return_value=(True, 100, 1)),
+        ):
+            result = service.get_page_result(
+                ticket_id=ticket.ticket_id,
+                result_store=store,
+                page=1,
+                page_size=10,
+                sort_by=None,
+                sort_order=SortOrder.asc,
+            )
+
+        assert isinstance(result, KWICPageResult)
+        assert result.display_limited is True
+        assert result.display_limit == 100
+        assert result.total_pages == 1
+    finally:
+        asyncio.run(store.shutdown())
+
+
+def test_get_page_result_propagates_uncapped_flag(tmp_path):
+    """get_page_result must pass display_limited=False through when not capped."""
+    store = _make_store(tmp_path)
+    service = KWICTicketService()
+
+    asyncio.run(store.startup())
+    try:
+        ticket = store.create_ticket(query_meta={"search": "test"})
+        store.store_ready(ticket.ticket_id, df=_make_df(5))
+
+        with (
+            patch("api_swedeb.api.services.kwic_ticket_service.ConfigValue.resolve", return_value=False),
+            patch.object(service, "_display_cap", return_value=(False, None, 1)),
+        ):
+            result = service.get_page_result(
+                ticket_id=ticket.ticket_id,
+                result_store=store,
+                page=1,
+                page_size=10,
+                sort_by=None,
+                sort_order=SortOrder.asc,
+            )
+
+        assert isinstance(result, KWICPageResult)
+        assert result.display_limited is False
+        assert result.display_limit is None
+    finally:
+        asyncio.run(store.shutdown())

--- a/tests/config.yml
+++ b/tests/config.yml
@@ -35,6 +35,8 @@ startup:
 kwic:
   use_multiprocessing: true
   num_processes: 8
+  large_result_threshold: 10000
+  large_result_display_limit: 1000
 
 celery:
   broker_url: redis://redis:6379/0

--- a/tests/profile_kwic.py
+++ b/tests/profile_kwic.py
@@ -1,0 +1,132 @@
+"""Standalone pyinstrument profiling script for the KWIC hot path.
+
+Exercises the exact same path that the KWIC API endpoint runs:
+  1. Bootstrap config and load CorpusLoader (cold-start cost, done once).
+  2. Build a CWB corpus connection.
+  3. Call ``KWICService.get_kwic()`` for the target word.
+
+This lets pyinstrument show where time is spent inside ``kwic_with_decode``,
+CWB/CQP query execution, and result decoding without HTTP or Celery overhead.
+
+Usage::
+
+    # Quick terminal flamegraph
+    uv run pyinstrument tests/profile_kwic.py
+
+    # HTML report via Makefile target
+    make profile-kwic-pyinstrument
+
+    # Different word or context window
+    uv run pyinstrument tests/profile_kwic.py --word skola --words-before 3 --words-after 3
+
+    # cProfile + snakeviz
+    uv run python -m cProfile -o tests/output/kwic.prof tests/profile_kwic.py
+    uv run snakeviz tests/output/kwic.prof
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import time
+import uuid
+
+from loguru import logger
+
+logger.remove()
+logger.add(sys.stderr, level="INFO", format="<level>{level}</level>: {message}")
+
+# pylint: disable=import-outside-toplevel
+
+
+def _parse_bool(v: str) -> bool:
+    if v.lower() in ("true", "yes", "1", "y"):
+        return True
+    if v.lower() in ("false", "no", "0", "n"):
+        return False
+    raise argparse.ArgumentTypeError(f"Expected true/false, got: {v!r}")
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Profile KWIC query hot path.")
+    parser.add_argument("--config", default="config/config.yml", metavar="PATH", help="Config YAML path.")
+    parser.add_argument("--word", default="och", help="Search word (default: och).")
+    parser.add_argument("--words-before", type=int, default=5, help="Context tokens before keyword (default: 5).")
+    parser.add_argument("--words-after", type=int, default=5, help="Context tokens after keyword (default: 5).")
+    parser.add_argument("--from-year", type=int, default=None, help="Start year filter.")
+    parser.add_argument("--to-year", type=int, default=None, help="End year filter.")
+    parser.add_argument(
+        "--lemmatized", type=_parse_bool, default=True, metavar="BOOL", help="Search lemmatized form (default: true)."
+    )
+    parser.add_argument("--cut-off", type=int, default=200_000, help="Max concordance hits (default: 200000).")
+    parser.add_argument(
+        "--num-processes",
+        type=int,
+        default=None,
+        help="Number of processes for multiprocessing (default: read from config or use cpu_count()).",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = _parse_args()
+    use_multiprocessing: bool | None = None if args.num_processes is None else (args.num_processes > 1)
+
+    from api_swedeb.api.params import build_common_query_params
+    from api_swedeb.api.services.corpus_loader import CorpusLoader
+    from api_swedeb.api.services.kwic_service import KWICService
+    from api_swedeb.core.configuration.inject import ConfigValue, get_config_store
+
+    import ccc
+
+    get_config_store().configure_context(source=args.config)
+
+    registry_dir: str = ConfigValue("cwb.registry_dir").resolve()
+    corpus_name: str = ConfigValue("cwb.corpus_name").resolve()
+
+    print(f"# Profile KWIC: word='{args.word}'  context={args.words_before}+{args.words_after}", flush=True)
+    print(f"  corpus={corpus_name}  cut_off={args.cut_off:,}", flush=True)
+    print("=" * 72, flush=True)
+
+    # --- Load corpus (mirrors API worker cold-start) -------------------------
+    t0 = time.perf_counter()
+    print("Loading CorpusLoader…", flush=True)
+    loader = CorpusLoader()
+    _ = loader.person_codecs
+    _ = loader.document_index
+    _ = loader.decoded_persons
+    _ = loader.prebuilt_speech_index
+    print(f"  corpus ready in {time.perf_counter() - t0:.2f}s", flush=True)
+
+    kwic_service = KWICService(loader=loader)
+
+    commons = build_common_query_params(
+        from_year=args.from_year,
+        to_year=args.to_year,
+    )
+
+    data_dir = f"/tmp/ccc-profile-kwic-{uuid.uuid4().hex[:8]}"
+    corpus = ccc.Corpora(registry_dir=registry_dir).corpus(corpus_name=corpus_name, data_dir=data_dir)
+
+    # --- Hot path: KWIC query ------------------------------------------------
+    print(f"\nRunning get_kwic('{args.word}', before={args.words_before}, after={args.words_after})…", flush=True)
+    t1 = time.perf_counter()
+    data = kwic_service.get_kwic(
+        corpus=corpus,
+        commons=commons,
+        keywords=args.word,
+        lemmatized=args.lemmatized,
+        words_before=args.words_before,
+        words_after=args.words_after,
+        cut_off=args.cut_off,
+        use_multiprocessing=use_multiprocessing,
+        n_processes=args.num_processes,
+    )
+    elapsed = time.perf_counter() - t1
+
+    print(f"  done in {elapsed:.2f}s  →  {len(data):,} rows", flush=True)
+    print("=" * 72, flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/profile_kwic.py
+++ b/tests/profile_kwic.py
@@ -72,12 +72,12 @@ def main() -> None:
     args = _parse_args()
     use_multiprocessing: bool | None = None if args.num_processes is None else (args.num_processes > 1)
 
+    import ccc
+
     from api_swedeb.api.params import build_common_query_params
     from api_swedeb.api.services.corpus_loader import CorpusLoader
     from api_swedeb.api.services.kwic_service import KWICService
     from api_swedeb.core.configuration.inject import ConfigValue, get_config_store
-
-    import ccc
 
     get_config_store().configure_context(source=args.config)
 

--- a/tests/profile_kwic.py
+++ b/tests/profile_kwic.py
@@ -31,6 +31,7 @@ import sys
 import time
 import uuid
 
+import ccc
 from loguru import logger
 
 logger.remove()
@@ -71,8 +72,6 @@ def _parse_args() -> argparse.Namespace:
 def main() -> None:
     args = _parse_args()
     use_multiprocessing: bool | None = None if args.num_processes is None else (args.num_processes > 1)
-
-    import ccc
 
     from api_swedeb.api.params import build_common_query_params
     from api_swedeb.api.services.corpus_loader import CorpusLoader


### PR DESCRIPTION
Introduce a new endpoint for estimating hit counts in KWIC searches, allowing users to gauge potential results before executing a query. Implement a server-side display cap for large result sets to enhance performance and user experience. Update configuration for thresholds and limits, and extend relevant schemas and services. Ensure comprehensive testing for both new features.

Fixes #356, #358