### PR TITLE
feat(kwic): progressive shard delivery for KWIC results

### DIFF
--- a/api_swedeb/api/services/kwic_service.py
+++ b/api_swedeb/api/services/kwic_service.py
@@ -1,6 +1,7 @@
 """KWIC (Keyword In Context) analysis service for parliamentary speech data."""
 
 import multiprocessing as mp
+from collections.abc import Callable
 
 import ccc
 import pandas as pd
@@ -45,6 +46,8 @@ class KWICService:
         cut_off: int | None = 200000,
         use_multiprocessing: bool | None = None,  # None = read from config
         n_processes: int | None = None,
+        on_shards_total: Callable[[int], None] | None = None,
+        on_shard_complete: Callable[[int, pd.DataFrame], None] | None = None,
     ) -> pd.DataFrame:
         """Get keyword in context data from corpus.
 
@@ -59,6 +62,8 @@ class KWICService:
             cut_off: Maximum number of hits to return
             use_multiprocessing: Whether to use multiprocessing (overrides config if not None)
             n_processes: Number of processes for multiprocessing (overrides config if not None)
+            on_shards_total: Optional callback fired once with total shard count (multiprocess only).
+            on_shard_complete: Optional callback fired per decoded shard (multiprocess only).
 
         Returns:
             DataFrame with KWIC data
@@ -84,6 +89,8 @@ class KWICService:
             cut_off=cut_off,
             use_multiprocessing=resolved_use_multiprocessing,
             num_processes=n_processes or ConfigValue("kwic.num_processes", default=8).resolve(),
+            on_shards_total=on_shards_total,
+            on_shard_complete=on_shard_complete,
         )
 
         return data

--- a/api_swedeb/api/services/kwic_ticket_service.py
+++ b/api_swedeb/api/services/kwic_ticket_service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import math
 import time
@@ -268,6 +269,8 @@ class KWICTicketService:
 
         if ticket.status == TicketStatus.PENDING:
             return status_model
+        if ticket.status == TicketStatus.ERROR:
+            return status_model
 
         if page < 1:
             raise ValueError("Page must be greater than or equal to 1")
@@ -388,7 +391,7 @@ class KWICTicketService:
 
         return (sort_by.value, TICKET_ROW_ID), (sort_order == SortOrder.asc, True)
 
-    def get_full_artifact(self, ticket_id: str, result_store: ResultStore) -> pd.DataFrame:
+    async def get_full_artifact(self, ticket_id: str, result_store: ResultStore) -> pd.DataFrame:
         result_store.touch_ticket(ticket_id)
         celery_enabled = ConfigValue("development.celery_enabled", default=False).resolve()
 
@@ -406,7 +409,7 @@ class KWICTicketService:
                 ticket = result_store.get_ticket(ticket_id)
                 if ticket is not None and ticket.status == TicketStatus.ERROR:
                     raise ResultStoreNotFound("Ticket query failed")
-                time.sleep(2)
+                await asyncio.sleep(2)
             try:
                 data: pd.DataFrame = pd.read_feather(artifact_path)
             except Exception as exc:
@@ -426,7 +429,7 @@ class KWICTicketService:
                         status_code=503,
                         detail="Download timed out waiting for KWIC query to complete",
                     )
-                time.sleep(2)
+                await asyncio.sleep(2)
             data = result_store.load_artifact(ticket_id)
 
         return data.drop(columns=[TICKET_ROW_ID], errors="ignore")

--- a/api_swedeb/api/services/kwic_ticket_service.py
+++ b/api_swedeb/api/services/kwic_ticket_service.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import math
+import time
 from collections.abc import Sequence
 from datetime import UTC, datetime, timedelta
 from functools import lru_cache
@@ -10,6 +11,7 @@ from typing import Any
 
 import ccc
 import pandas as pd
+from fastapi import HTTPException
 from loguru import logger
 
 from api_swedeb.api.params import CommonQueryParams, build_common_query_params, build_filter_opts
@@ -129,6 +131,18 @@ class KWICTicketService:
                 speech_id=request.filters.speech_id,
             )
             keywords: str | list[str] = self._keywords(request.search)
+
+            # Shard-delivery callbacks (multiprocess path only)
+            is_multiprocess: list[bool] = [False]
+
+            def on_shards_total(n: int) -> None:
+                is_multiprocess[0] = True
+                result_store.set_shards_total(ticket_id, n)
+
+            def on_shard_complete(shard_index: int, decoded_df: pd.DataFrame) -> None:
+                shard_frame = kwic_to_api_frame(decoded_df).reset_index(drop=True)
+                result_store.store_shard(ticket_id, shard_index, shard_frame)
+
             logger.debug(f"Calling get_kwic for ticket {ticket_id}")
             data: pd.DataFrame = kwic_service.get_kwic(
                 corpus=corpus,
@@ -139,19 +153,33 @@ class KWICTicketService:
                 words_after=request.words_after,
                 cut_off=request.cut_off,
                 p_show="word",
+                on_shards_total=on_shards_total,
+                on_shard_complete=on_shard_complete,
             )
             logger.info(f"KWIC query completed for ticket {ticket_id}, found {len(data)} rows")
             logger.debug(f"Converting to API frame for ticket {ticket_id}")
-            api_frame: pd.DataFrame = kwic_to_api_frame(data).reset_index(drop=True)
-            api_frame[TICKET_ROW_ID] = range(len(api_frame.index))
-            logger.debug(f"Storing results for ticket {ticket_id}")
-            result_store.store_ready(
-                ticket_id,
-                df=api_frame,
-                query_meta=self._query_meta(request),
-                speech_ids=self._speech_ids(api_frame),
-                manifest_meta=self._manifest_meta(ticket_id, request, api_frame),
-            )
+
+            if is_multiprocess[0]:
+                # Shards have been written; merge from disk and transition to READY
+                api_frame: pd.DataFrame = kwic_to_api_frame(data).reset_index(drop=True)
+                logger.debug(f"Merging shards for ticket {ticket_id}")
+                result_store.store_shards_ready(
+                    ticket_id,
+                    query_meta=self._query_meta(request),
+                    speech_ids=self._speech_ids(api_frame),
+                    manifest_meta=self._manifest_meta(ticket_id, request, api_frame),
+                )
+            else:
+                api_frame = kwic_to_api_frame(data).reset_index(drop=True)
+                api_frame[TICKET_ROW_ID] = range(len(api_frame.index))
+                logger.debug(f"Storing results for ticket {ticket_id}")
+                result_store.store_ready(
+                    ticket_id,
+                    df=api_frame,
+                    query_meta=self._query_meta(request),
+                    speech_ids=self._speech_ids(api_frame),
+                    manifest_meta=self._manifest_meta(ticket_id, request, api_frame),
+                )
             logger.info(f"Successfully stored results for ticket {ticket_id}")
         except ResultStoreCapacityError:
             logger.warning(f"Result store capacity error for ticket {ticket_id}")
@@ -190,6 +218,9 @@ class KWICTicketService:
         elif status == TicketStatus.ERROR:
             error: str = str(celery_result.info) if celery_result.info else "Task failed"
             ticket = result_store.sync_external_error(ticket_id, message=error)
+        elif status == TicketStatus.PENDING:
+            # Check if shards have started arriving (PARTIAL)
+            ticket = result_store.sync_external_partial(ticket_id)
 
         return self._status_model(ticket)
 
@@ -233,7 +264,9 @@ class KWICTicketService:
         sort_order: SortOrder,
     ) -> KWICPageResult | KWICTicketStatus:
         status_model: KWICTicketStatus = self._get_celery_status(ticket_id, result_store)
-        if status_model.status != TicketStatus.READY.value:
+        ticket = result_store.require_ticket(ticket_id)
+
+        if ticket.status == TicketStatus.PENDING:
             return status_model
 
         if page < 1:
@@ -241,18 +274,20 @@ class KWICTicketService:
         if page_size < 1 or page_size > result_store.max_page_size:
             raise ValueError(f"page_size must be between 1 and {result_store.max_page_size}")
 
-        artifact_path: Path = result_store.artifact_path(ticket_id)
-        if not artifact_path.exists():
-            raise ResultStoreNotFound("Ticket artifact not found or expired")
-        try:
-            data = pd.read_feather(artifact_path)
-        except Exception as exc:
-            raise ResultStoreNotFound("Ticket artifact not found or expired") from exc
+        is_partial = ticket.status == TicketStatus.PARTIAL
+        if is_partial:
+            data = result_store.load_artifact(ticket_id)
+        else:
+            artifact_path: Path = result_store.artifact_path(ticket_id)
+            if not artifact_path.exists():
+                raise ResultStoreNotFound("Ticket artifact not found or expired")
+            try:
+                data = pd.read_feather(artifact_path)
+            except Exception as exc:
+                raise ResultStoreNotFound("Ticket artifact not found or expired") from exc
 
         total_hits: int = len(data.index)
         total_pages: int = math.ceil(total_hits / page_size) if total_hits else 0
-        display_limited, display_limit, total_pages = self._display_cap(total_hits, total_pages, page_size)
-        ticket: TicketMeta | None = result_store.get_ticket(ticket_id)
         expires_at: datetime = ticket.expires_at if ticket is not None else (datetime.now(UTC) + timedelta(seconds=600))
 
         if total_pages == 0:
@@ -274,14 +309,14 @@ class KWICTicketService:
 
         return KWICPageResult(
             ticket_id=ticket_id,
-            status="ready",
+            status=ticket.status.value,
             page=page,
             page_size=page_size,
             total_hits=total_hits,
             total_pages=total_pages,
-            display_limited=display_limited,
-            display_limit=display_limit,
             expires_at=expires_at,
+            shards_complete=ticket.shards_complete,
+            shards_total=ticket.shards_total,
             kwic_list=kwic_api_frame_to_model(page_frame).kwic_list,
         )
 
@@ -297,9 +332,13 @@ class KWICTicketService:
     ) -> KWICPageResult | KWICTicketStatus:
         ticket: TicketMeta = result_store.require_ticket(ticket_id)
         status_model: KWICTicketStatus = self._status_model(ticket)
-        if ticket.status != TicketStatus.READY:
+
+        if ticket.status == TicketStatus.PENDING:
+            return status_model
+        if ticket.status == TicketStatus.ERROR:
             return status_model
 
+        # PARTIAL or READY: serve available data
         if page < 1:
             raise ValueError("Page must be greater than or equal to 1")
         if page_size < 1 or page_size > result_store.max_page_size:
@@ -308,7 +347,6 @@ class KWICTicketService:
         data: pd.DataFrame = result_store.load_artifact(ticket_id)
         total_hits: int = len(data.index)
         total_pages: int = math.ceil(total_hits / page_size) if total_hits else 0
-        display_limited, display_limit, total_pages = self._display_cap(total_hits, total_pages, page_size)
         if total_pages == 0:
             if page != 1:
                 raise ValueError("Requested page is out of range")
@@ -328,14 +366,14 @@ class KWICTicketService:
 
         return KWICPageResult(
             ticket_id=ticket.ticket_id,
-            status="ready",
+            status=ticket.status.value,
             page=page,
             page_size=page_size,
             total_hits=total_hits,
             total_pages=total_pages,
-            display_limited=display_limited,
-            display_limit=display_limit,
             expires_at=ticket.expires_at,
+            shards_complete=ticket.shards_complete,
+            shards_total=ticket.shards_total,
             kwic_list=kwic_api_frame_to_model(page_frame).kwic_list,
         )
 
@@ -350,49 +388,45 @@ class KWICTicketService:
 
         return (sort_by.value, TICKET_ROW_ID), (sort_order == SortOrder.asc, True)
 
-    def _display_cap(self, total_hits: int, total_pages: int, page_size: int) -> tuple[bool, int | None, int]:
-        """Return (display_limited, display_limit, effective_total_pages).
-
-        When *total_hits* is below the configured threshold the result is
-        uncapped and the original *total_pages* is returned unchanged.
-        """
-        default_threshold = 10000
-        default_display_limit = 1000
-
-        try:
-            threshold = int(ConfigValue("kwic.large_result_threshold", default=default_threshold).resolve())
-        except (TypeError, ValueError):
-            threshold = default_threshold
-        if threshold <= 0:
-            threshold = default_threshold
-
-        if total_hits < threshold:
-            return False, None, total_pages
-
-        try:
-            display_limit = int(ConfigValue("kwic.large_result_display_limit", default=default_display_limit).resolve())
-        except (TypeError, ValueError):
-            display_limit = default_display_limit
-        if display_limit <= 0:
-            display_limit = default_display_limit
-
-        capped_pages: int = math.ceil(display_limit / page_size)
-        return True, display_limit, min(capped_pages, total_pages)
-
     def get_full_artifact(self, ticket_id: str, result_store: ResultStore) -> pd.DataFrame:
         result_store.touch_ticket(ticket_id)
-        if ConfigValue("development.celery_enabled", default=False).resolve():
+        celery_enabled = ConfigValue("development.celery_enabled", default=False).resolve()
+
+        if celery_enabled:
+            # For Celery path, block-poll until the artifact file appears on disk
+            timeout_s = int(ConfigValue("kwic.download_wait_timeout_s", default=300).resolve())
+            deadline = time.monotonic() + timeout_s
             artifact_path: Path = result_store.artifact_path(ticket_id)
-            if not artifact_path.exists():
-                raise ResultStoreNotFound("Ticket artifact not found or expired")
+            while not artifact_path.exists():
+                if time.monotonic() >= deadline:
+                    raise HTTPException(
+                        status_code=503,
+                        detail="Download timed out waiting for KWIC query to complete",
+                    )
+                ticket = result_store.get_ticket(ticket_id)
+                if ticket is not None and ticket.status == TicketStatus.ERROR:
+                    raise ResultStoreNotFound("Ticket query failed")
+                time.sleep(2)
             try:
                 data: pd.DataFrame = pd.read_feather(artifact_path)
             except Exception as exc:
                 raise ResultStoreNotFound("Ticket artifact not found or expired") from exc
         else:
-            ticket: TicketMeta = result_store.require_ticket(ticket_id)
-            if ticket.status != TicketStatus.READY:
-                raise ResultStoreNotFound("Ticket is not ready")
+            # Local path: block-poll until READY (handles both PARTIAL and PENDING)
+            timeout_s = int(ConfigValue("kwic.download_wait_timeout_s", default=300).resolve())
+            deadline = time.monotonic() + timeout_s
+            while True:
+                ticket = result_store.require_ticket(ticket_id)
+                if ticket.status == TicketStatus.READY:
+                    break
+                if ticket.status == TicketStatus.ERROR:
+                    raise ResultStoreNotFound("Ticket query failed")
+                if time.monotonic() >= deadline:
+                    raise HTTPException(
+                        status_code=503,
+                        detail="Download timed out waiting for KWIC query to complete",
+                    )
+                time.sleep(2)
             data = result_store.load_artifact(ticket_id)
 
         return data.drop(columns=[TICKET_ROW_ID], errors="ignore")
@@ -455,6 +489,8 @@ class KWICTicketService:
             total_hits=ticket.total_hits,
             error=ticket.error,
             expires_at=ticket.expires_at,
+            shards_complete=ticket.shards_complete,
+            shards_total=ticket.shards_total,
         )
 
     def _keywords(self, search: str) -> str | list[str]:

--- a/api_swedeb/api/services/result_store.py
+++ b/api_swedeb/api/services/result_store.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import shutil
 from collections import OrderedDict
 from collections.abc import Sequence
 from contextlib import suppress
@@ -17,9 +18,12 @@ import pandas as pd
 from api_swedeb.api.services.ticket_state_store import TicketStateStore, serialize_ticket_meta
 from api_swedeb.core.configuration import ConfigValue
 
+TICKET_ROW_ID = "_ticket_row_id"
+
 
 class TicketStatus(StrEnum):
     PENDING = "pending"
+    PARTIAL = "partial"
     READY = "ready"
     ERROR = "error"
 
@@ -40,6 +44,8 @@ class TicketMeta:
     ready_at: datetime | None = None
     source_ticket_id: str | None = None
     archive_format: str | None = None
+    shards_complete: int = 0
+    shards_total: int = 0
 
 
 class ResultStoreError(RuntimeError):
@@ -91,10 +97,10 @@ class ResultStore:
         self._started = False
         self._tickets: dict[str, TicketMeta] = {}
         self._cleanup_task: asyncio.Task[None] | None = None
-        self._artifact_cache: OrderedDict[str, pd.DataFrame] = OrderedDict()
-        self._sorted_positions_cache: OrderedDict[tuple[str, tuple[str, ...], tuple[bool, ...]], tuple[int, ...]] = (
-            OrderedDict()
-        )
+        self._artifact_cache: OrderedDict[tuple[str, int], pd.DataFrame] = OrderedDict()
+        self._sorted_positions_cache: OrderedDict[
+            tuple[str, int, tuple[str, ...], tuple[bool, ...]], tuple[int, ...]
+        ] = OrderedDict()
 
     @classmethod
     def from_config(cls) -> "ResultStore":
@@ -327,6 +333,10 @@ class ResultStore:
 
     def load_artifact(self, ticket_id: str) -> pd.DataFrame:
         ticket = self.require_ticket(ticket_id)
+
+        if ticket.status == TicketStatus.PARTIAL:
+            return self._load_partial_artifact(ticket)
+
         if ticket.artifact_path is None:
             raise ResultStoreNotFound("Ticket artifact not found or expired")
         if not ticket.artifact_path.exists():
@@ -336,10 +346,12 @@ class ResultStore:
                     self._delete_ticket_locked(ticket_id)
             raise ResultStoreNotFound("Ticket artifact not found or expired")
 
+        shards_complete = ticket.shards_complete
         with self._lock:
-            cached = self._artifact_cache.get(ticket_id)
+            cache_key = (ticket_id, shards_complete)
+            cached = self._artifact_cache.get(cache_key)
             if cached is not None:
-                self._artifact_cache.move_to_end(ticket_id)
+                self._artifact_cache.move_to_end(cache_key)
                 return cached
 
         try:
@@ -352,8 +364,33 @@ class ResultStore:
             raise ResultStoreNotFound("Ticket artifact not found or expired") from exc
 
         with self._lock:
-            self._cache_artifact_locked(ticket_id, artifact)
+            self._cache_artifact_locked(ticket_id, shards_complete, artifact)
         return artifact
+
+    def _load_partial_artifact(self, ticket: TicketMeta) -> pd.DataFrame:
+        """Concatenate available shard files and return a DataFrame with temporary row IDs."""
+        shards_complete = ticket.shards_complete
+        with self._lock:
+            cache_key = (ticket.ticket_id, shards_complete)
+            cached = self._artifact_cache.get(cache_key)
+            if cached is not None:
+                self._artifact_cache.move_to_end(cache_key)
+                return cached
+
+        shard_dir = self._shard_dir(ticket.ticket_id)
+        shard_files = sorted(shard_dir.glob("shard_*.feather"))
+        if not shard_files:
+            empty = pd.DataFrame()
+            empty[TICKET_ROW_ID] = pd.Series(dtype="int64")
+            return empty
+
+        dfs = [pd.read_feather(f) for f in shard_files]
+        merged = pd.concat(dfs, ignore_index=True)
+        merged[TICKET_ROW_ID] = range(len(merged))
+
+        with self._lock:
+            self._cache_artifact_locked(ticket.ticket_id, shards_complete, merged)
+        return merged
 
     def get_sorted_positions(
         self,
@@ -363,7 +400,9 @@ class ResultStore:
         ascending: Sequence[bool],
     ) -> tuple[int, ...]:
         data = self.load_artifact(ticket_id)
-        cache_key = (ticket_id, tuple(sort_columns), tuple(ascending))
+        ticket = self.require_ticket(ticket_id)
+        shards_complete = ticket.shards_complete
+        cache_key = (ticket_id, shards_complete, tuple(sort_columns), tuple(ascending))
 
         with self._lock:
             cached = self._sorted_positions_cache.get(cache_key)
@@ -439,6 +478,187 @@ class ResultStore:
             self._set_ticket_locked(updated)
             return replace(updated)
 
+    def set_shards_total(
+        self,
+        ticket_id: str,
+        n: int,
+        *,
+        reserved_bytes: int = 0,
+    ) -> TicketMeta:
+        """Record the total number of shards and transition ticket to PARTIAL.
+
+        Called inside ``execute_kwic_multiprocess`` immediately after computing
+        ``year_chunks``, before the pool starts.  Pre-reserves *reserved_bytes*
+        so capacity accounting blocks new tickets if there is not enough headroom.
+        """
+        shard_dir = self._shard_dir(ticket_id)
+        shard_dir.mkdir(parents=True, exist_ok=True)
+
+        with self._lock, self._state_lock():
+            self._ensure_started_locked()
+            ticket = self._get_ticket_locked(ticket_id)
+            if ticket is None:
+                raise ResultStoreNotFound("Ticket not found or expired")
+
+            if reserved_bytes > 0:
+                self._evict_ready_tickets_locked(required_bytes=reserved_bytes, exclude_ticket_id=ticket_id)
+                total_capacity = self._artifact_bytes_locked() + reserved_bytes - (ticket.artifact_bytes or 0)
+                if reserved_bytes > self.max_artifact_bytes or total_capacity > self.max_artifact_bytes:
+                    shutil.rmtree(shard_dir, ignore_errors=True)
+                    message = "Insufficient result-store capacity for ticket artifact"
+                    self._set_ticket_locked(replace(ticket, status=TicketStatus.ERROR, error=message))
+                    raise ResultStoreCapacityError(message)
+
+            updated = replace(
+                ticket,
+                status=TicketStatus.PARTIAL,
+                shards_total=n,
+                shards_complete=0,
+                artifact_bytes=reserved_bytes if reserved_bytes > 0 else ticket.artifact_bytes,
+            )
+            self._set_ticket_locked(updated)
+            return replace(updated)
+
+    def store_shard(
+        self,
+        ticket_id: str,
+        shard_index: int,
+        df: pd.DataFrame,
+    ) -> TicketMeta:
+        """Atomically write a shard file and advance ``shards_complete``.
+
+        Called per-shard from the ``on_shard_complete`` callback in
+        ``execute_ticket``.  The *df* must already be an API frame (output of
+        ``kwic_to_api_frame``), without ``TICKET_ROW_ID`` assigned.
+        """
+        shard_dir = self._shard_dir(ticket_id)
+        tmp_path = shard_dir / f"shard_{shard_index:04d}.feather.tmp"
+        shard_path = self._shard_path(ticket_id, shard_index)
+
+        df_to_save = df.copy()
+        for col in df_to_save.columns:
+            if hasattr(df_to_save[col].dtype, "pyarrow_dtype"):
+                df_to_save[col] = df_to_save[col].astype("object")
+
+        df_to_save.to_feather(tmp_path, compression="lz4")
+        tmp_path.replace(shard_path)
+
+        with self._lock, self._state_lock():
+            self._ensure_started_locked()
+            ticket = self._get_ticket_locked(ticket_id)
+            if ticket is None:
+                shard_path.unlink(missing_ok=True)
+                raise ResultStoreNotFound("Ticket not found or expired")
+
+            new_count = ticket.shards_complete + 1
+            total_hits = (ticket.total_hits or 0) + len(df.index)
+            updated = replace(
+                ticket,
+                status=TicketStatus.PARTIAL,
+                shards_complete=new_count,
+                total_hits=total_hits,
+            )
+            self._invalidate_ticket_cache_locked(ticket_id)
+            self._set_ticket_locked(updated)
+            return replace(updated)
+
+    def store_shards_ready(
+        self,
+        ticket_id: str,
+        *,
+        query_meta: dict | None = None,
+        speech_ids: list[str] | None = None,
+        manifest_meta: dict | None = None,
+    ) -> TicketMeta:
+        """Merge all shard files, assign ``TICKET_ROW_ID``, and transition to READY.
+
+        Called after ``execute_kwic_multiprocess`` returns (all shards complete).
+        """
+        shard_dir = self._shard_dir(ticket_id)
+        shard_files = sorted(shard_dir.glob("shard_*.feather"))
+
+        if shard_files:
+            dfs = [pd.read_feather(f) for f in shard_files]
+            merged = pd.concat(dfs, ignore_index=True)
+        else:
+            merged = pd.DataFrame()
+
+        merged[TICKET_ROW_ID] = range(len(merged))
+
+        artifact_path = self._artifact_path(ticket_id)
+        tmp_path = self._partial_path(ticket_id)
+
+        merged_to_save = merged.copy()
+        for col in merged_to_save.columns:
+            if hasattr(merged_to_save[col].dtype, "pyarrow_dtype"):
+                merged_to_save[col] = merged_to_save[col].astype("object")
+
+        merged_to_save.to_feather(tmp_path, compression="lz4")
+        artifact_bytes = tmp_path.stat().st_size
+
+        with self._lock, self._state_lock():
+            self._ensure_started_locked()
+            ticket = self._get_ticket_locked(ticket_id)
+            if ticket is None:
+                tmp_path.unlink(missing_ok=True)
+                raise ResultStoreNotFound("Ticket not found or expired")
+
+            tmp_path.replace(artifact_path)
+            shutil.rmtree(shard_dir, ignore_errors=True)
+
+            self._invalidate_ticket_cache_locked(ticket_id)
+            ready_at = datetime.now(UTC)
+            updated = replace(
+                ticket,
+                status=TicketStatus.READY,
+                expires_at=self._clamped_expiry(
+                    ticket.created_at, ready_at + timedelta(seconds=self.result_ttl_seconds)
+                ),
+                query_meta=dict(query_meta or ticket.query_meta),
+                artifact_path=artifact_path,
+                artifact_bytes=artifact_bytes,
+                total_hits=len(merged.index),
+                speech_ids=list(speech_ids) if speech_ids is not None else ticket.speech_ids,
+                manifest_meta=dict(manifest_meta) if manifest_meta is not None else ticket.manifest_meta,
+                error=None,
+                ready_at=ready_at,
+            )
+            self._set_ticket_locked(updated)
+            return replace(updated)
+
+    def sync_external_partial(self, ticket_id: str) -> TicketMeta:
+        """Update in-memory shard progress from Redis (Celery path).
+
+        Called on each poll cycle when the ticket is not yet READY or ERROR,
+        so that the API process reflects cross-process shard writes made by
+        Celery workers.
+        """
+        if self.ticket_state_store is None:
+            return self.require_ticket(ticket_id)
+
+        with self._lock, self._state_lock():
+            self._ensure_started_locked()
+            ticket = self._get_ticket_locked(ticket_id)
+            if ticket is None:
+                raise ResultStoreNotFound("Ticket not found or expired")
+
+            if ticket.status in (TicketStatus.READY, TicketStatus.ERROR):
+                return replace(ticket)
+
+            shards_complete, shards_total = self.ticket_state_store.get_shard_progress(ticket_id)
+            if shards_total == 0:
+                return replace(ticket)
+
+            new_status = TicketStatus.PARTIAL if shards_complete < shards_total else ticket.status
+            updated = replace(
+                ticket,
+                shards_complete=shards_complete,
+                shards_total=shards_total,
+                status=new_status,
+            )
+            self._set_ticket_locked(updated)
+            return replace(updated)
+
     def store_error(self, ticket_id: str, *, message: str) -> TicketMeta:
         with self._lock, self._state_lock():
             ticket = self._get_ticket_locked(ticket_id)
@@ -472,6 +692,12 @@ class ResultStore:
 
     def _artifact_path(self, ticket_id: str) -> Path:
         return self.root_dir / f"{ticket_id}{self.ARTIFACT_SUFFIX}"
+
+    def _shard_dir(self, ticket_id: str) -> Path:
+        return self.root_dir / ticket_id
+
+    def _shard_path(self, ticket_id: str, shard_index: int) -> Path:
+        return self._shard_dir(ticket_id) / f"shard_{shard_index:04d}.feather"
 
     def _partial_path(self, ticket_id: str) -> Path:
         return self.root_dir / f"{ticket_id}{self.ARTIFACT_SUFFIX}{self.PARTIAL_SUFFIX}"
@@ -551,6 +777,11 @@ class ResultStore:
                 for path in archives_dir.glob(f"*{suffix}"):
                     path.unlink(missing_ok=True)
 
+        # Remove orphaned shard directories (uuid-named dirs that are not "archives")
+        for candidate in self.root_dir.iterdir():
+            if candidate.is_dir() and candidate.name != "archives":
+                shutil.rmtree(candidate, ignore_errors=True)
+
     def _delete_ticket_locked(self, ticket_id: str) -> None:
         ticket = self._get_ticket_locked(ticket_id)
         if ticket is None:
@@ -560,10 +791,12 @@ class ResultStore:
         self._delete_ticket_metadata_locked(ticket_id)
 
     def _remove_artifact_locked(self, ticket: TicketMeta) -> None:
-        if ticket.artifact_path is None:
-            return
-        if ticket.artifact_path.exists():
+        if ticket.artifact_path is not None and ticket.artifact_path.exists():
             ticket.artifact_path.unlink(missing_ok=True)
+        # Also clean up shard directory if it exists (PARTIAL or leftover)
+        shard_dir = self._shard_dir(ticket.ticket_id)
+        if shard_dir.exists():
+            shutil.rmtree(shard_dir, ignore_errors=True)
 
     def _evict_ready_tickets_locked(self, *, required_bytes: int, exclude_ticket_id: str) -> None:
         if required_bytes <= 0:
@@ -600,7 +833,9 @@ class ResultStore:
         if self.ticket_state_store is not None:
             return self.ticket_state_store.get_artifact_bytes()
         return sum(
-            ticket.artifact_bytes or 0 for ticket in self._list_tickets_locked() if ticket.status == TicketStatus.READY
+            ticket.artifact_bytes or 0
+            for ticket in self._list_tickets_locked()
+            if ticket.status in (TicketStatus.READY, TicketStatus.PARTIAL)
         )
 
     def _build_sorted_positions(
@@ -614,22 +849,25 @@ class ResultStore:
         return tuple(int(index) for index in sorted_frame.index.to_list())
 
     def _invalidate_ticket_cache_locked(self, ticket_id: str) -> None:
-        self._artifact_cache.pop(ticket_id, None)
-        cache_keys = [cache_key for cache_key in self._sorted_positions_cache if cache_key[0] == ticket_id]
-        for cache_key in cache_keys:
-            self._sorted_positions_cache.pop(cache_key, None)
+        artifact_keys = [k for k in self._artifact_cache if k[0] == ticket_id]
+        for k in artifact_keys:
+            self._artifact_cache.pop(k, None)
+        sorted_keys = [k for k in self._sorted_positions_cache if k[0] == ticket_id]
+        for k in sorted_keys:
+            self._sorted_positions_cache.pop(k, None)
 
-    def _cache_artifact_locked(self, ticket_id: str, artifact: pd.DataFrame) -> None:
+    def _cache_artifact_locked(self, ticket_id: str, shards_complete: int, artifact: pd.DataFrame) -> None:
         if self.artifact_cache_max_entries <= 0:
             return
-        self._artifact_cache[ticket_id] = artifact
-        self._artifact_cache.move_to_end(ticket_id)
+        cache_key = (ticket_id, shards_complete)
+        self._artifact_cache[cache_key] = artifact
+        self._artifact_cache.move_to_end(cache_key)
         while len(self._artifact_cache) > self.artifact_cache_max_entries:
             self._artifact_cache.popitem(last=False)
 
     def _cache_sorted_positions_locked(
         self,
-        cache_key: tuple[str, tuple[str, ...], tuple[bool, ...]],
+        cache_key: tuple[str, int, tuple[str, ...], tuple[bool, ...]],
         positions: tuple[int, ...],
     ) -> None:
         if self.sorted_positions_cache_max_entries <= 0:
@@ -692,4 +930,6 @@ class ResultStore:
             ready_at=datetime.fromisoformat(payload["ready_at"]) if payload.get("ready_at") else None,
             source_ticket_id=payload.get("source_ticket_id"),
             archive_format=payload.get("archive_format"),
+            shards_complete=int(payload.get("shards_complete") or 0),
+            shards_total=int(payload.get("shards_total") or 0),
         )

--- a/api_swedeb/api/services/result_store.py
+++ b/api_swedeb/api/services/result_store.py
@@ -603,6 +603,20 @@ class ResultStore:
                 tmp_path.unlink(missing_ok=True)
                 raise ResultStoreNotFound("Ticket not found or expired")
 
+            self._evict_ready_tickets_locked(required_bytes=artifact_bytes, exclude_ticket_id=ticket_id)
+
+            if (
+                artifact_bytes > self.max_artifact_bytes
+                or self._artifact_bytes_locked() + artifact_bytes - (ticket.artifact_bytes or 0)
+                > self.max_artifact_bytes
+            ):
+                tmp_path.unlink(missing_ok=True)
+                shutil.rmtree(shard_dir, ignore_errors=True)
+                message = "Insufficient result-store capacity for ticket artifact"
+                self._invalidate_ticket_cache_locked(ticket_id)
+                self._set_ticket_locked(replace(ticket, status=TicketStatus.ERROR, error=message))
+                raise ResultStoreCapacityError(message)
+
             tmp_path.replace(artifact_path)
             shutil.rmtree(shard_dir, ignore_errors=True)
 
@@ -777,10 +791,17 @@ class ResultStore:
                 for path in archives_dir.glob(f"*{suffix}"):
                     path.unlink(missing_ok=True)
 
-        # Remove orphaned shard directories (uuid-named dirs that are not "archives")
+        active_partial_ticket_ids = {
+            ticket.ticket_id for ticket in self._list_tickets_locked() if ticket.status == TicketStatus.PARTIAL
+        }
+
+        # Remove only orphaned shard directories; preserve shards for active PARTIAL tickets.
         for candidate in self.root_dir.iterdir():
-            if candidate.is_dir() and candidate.name != "archives":
-                shutil.rmtree(candidate, ignore_errors=True)
+            if not candidate.is_dir() or candidate.name == "archives":
+                continue
+            if candidate.name in active_partial_ticket_ids:
+                continue
+            shutil.rmtree(candidate, ignore_errors=True)
 
     def _delete_ticket_locked(self, ticket_id: str) -> None:
         ticket = self._get_ticket_locked(ticket_id)

--- a/api_swedeb/api/services/ticket_state_store.py
+++ b/api_swedeb/api/services/ticket_state_store.py
@@ -109,6 +109,24 @@ class TicketStateStore:
     def get_artifact_bytes(self) -> int:
         return self._read_counter(self._artifact_bytes_key())
 
+    def set_shards_total(self, ticket_id: str, n: int) -> None:
+        """Record the total shard count for cross-process progress tracking."""
+        self._client.set(self._shard_total_key(ticket_id), n)
+
+    def increment_shards_complete(self, ticket_id: str) -> int:
+        """Atomically increment the shard-complete counter and return the new value."""
+        return int(cast(str, self._client.incr(self._shard_complete_key(ticket_id))))
+
+    def get_shard_progress(self, ticket_id: str) -> tuple[int, int]:
+        """Return ``(shards_complete, shards_total)`` from Redis counters."""
+        complete = self._read_counter(self._shard_complete_key(ticket_id))
+        total = self._read_counter(self._shard_total_key(ticket_id))
+        return complete, total
+
+    def delete_shard_progress(self, ticket_id: str) -> None:
+        """Remove shard counter keys when a ticket is deleted."""
+        self._client.delete(self._shard_complete_key(ticket_id), self._shard_total_key(ticket_id))
+
     def _ticket_key(self, ticket_id: str) -> str:
         return self._key(f"ticket:{ticket_id}")
 
@@ -120,6 +138,12 @@ class TicketStateStore:
 
     def _stats_initialized_key(self) -> str:
         return self._key("stats:initialized")
+
+    def _shard_total_key(self, ticket_id: str) -> str:
+        return self._key(f"shard:total:{ticket_id}")
+
+    def _shard_complete_key(self, ticket_id: str) -> str:
+        return self._key(f"shard:complete:{ticket_id}")
 
     def _key(self, suffix: str) -> str:
         return f"{self._key_prefix}:{suffix}"
@@ -147,7 +171,7 @@ class TicketStateStore:
     def _artifact_bytes_delta(self, payload: dict[str, Any] | None) -> int:
         if payload is None:
             return 0
-        if payload.get("status") != "ready":
+        if payload.get("status") not in ("ready", "partial"):
             return 0
         return int(payload.get("artifact_bytes") or 0)
 

--- a/api_swedeb/api/v1/endpoints/tool_router.py
+++ b/api_swedeb/api/v1/endpoints/tool_router.py
@@ -248,7 +248,7 @@ async def download_kwic_ticket(
     ticket = _require_ready_ticket(ticket_id, result_store)
 
     try:
-        data = kwic_ticket_service.get_full_artifact(ticket_id, result_store)
+        data = await kwic_ticket_service.get_full_artifact(ticket_id, result_store)
     except ResultStoreNotFound as exc:
         raise HTTPException(status_code=404, detail="Ticket artifact not found or expired") from exc
 

--- a/api_swedeb/core/kwic/multiprocess.py
+++ b/api_swedeb/core/kwic/multiprocess.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import multiprocessing as mp
 import os
 import tempfile
+from collections.abc import Callable
 from datetime import datetime
 from typing import Any, Literal
 
@@ -16,20 +17,20 @@ from .singleprocess import execute_kwic_singleprocess
 from .utility import create_year_chunks, empty_kwic, extract_year_range, inject_year_filter
 
 
-def kwic_worker(args: tuple) -> pd.DataFrame:
+def kwic_worker(args: tuple) -> tuple[int, pd.DataFrame]:
     """Worker function for multiprocessing kwic queries.
 
-    This function is designed to be called by multiprocessing.Pool.map().
+    This function is designed to be called by multiprocessing.Pool.imap_unordered().
     Each worker creates its own isolated work directory to avoid file locking conflicts.
 
     Args:
-        args: Tuple of (corpus_opts, opts, year_range, words_before, words_after, p_show, cut_off)
+        args: Tuple of (shard_index, corpus_opts, opts, year_range, words_before, words_after, p_show, cut_off)
 
     Returns:
-        DataFrame with kwic results for the specified year range
+        Tuple of (shard_index, DataFrame) with kwic results for the specified year range
     """
 
-    corpus_opts, opts, year_range, words_before, words_after, p_show, cut_off = args
+    shard_index, corpus_opts, opts, year_range, words_before, words_after, p_show, cut_off = args
 
     opts_with_year_range: list[dict[str, Any]] = inject_year_filter(opts, year_range)
 
@@ -58,7 +59,7 @@ def kwic_worker(args: tuple) -> pd.DataFrame:
             p_show=p_show,
             cut_off=cut_off,
         )
-        return result
+        return shard_index, result
     finally:
         # Clean up the temporary directory after processing
         # Note: We leave cleanup to the OS in case of crashes, but try to clean up on success
@@ -79,6 +80,8 @@ def execute_kwic_multiprocess(
     p_show: Literal["word", "lemma"],
     cut_off: int | None,
     num_processes: int | None,
+    on_shards_total: Callable[[int], None] | None = None,
+    on_shard_complete: Callable[[int, pd.DataFrame], None] | None = None,
 ) -> pd.DataFrame:
     """Execute KWIC query using multiprocessing with year-based partitioning.
 
@@ -90,7 +93,12 @@ def execute_kwic_multiprocess(
         p_show: What to display ('word' or 'lemma')
         cut_off: Maximum number of results
         num_processes: Number of processes to use (None = CPU count)
-        empty_result_fn: Function to call for empty results
+        on_shards_total: Optional callback invoked once with the total shard count
+                         before the pool starts.  Used by the ticket service to
+                         pre-register shard metadata.
+        on_shard_complete: Optional callback invoked per completed shard with
+                           (shard_index, raw_DataFrame).  Fired in completion
+                           order (imap_unordered), not submission order.
 
     Returns:
         Combined DataFrame from all worker processes
@@ -109,30 +117,36 @@ def execute_kwic_multiprocess(
     # Create year chunks
     year_chunks: list[tuple[int, int]] = create_year_chunks(min_year, max_year, num_processes)
 
+    # Notify caller of total shard count before pool starts (for capacity reservation)
+    if on_shards_total is not None:
+        on_shards_total(len(year_chunks))
+
     # Each shard uses the full global cut_off so that no year period is silently
-    # truncated before the merge.  Dividing cut_off by num_processes caused heavy
-    # years (e.g. recent decades for common words) to hit their per-shard ceiling
-    # and return far fewer results than the true corpus count.  The combined result
-    # is trimmed to the global limit after merging, so correctness is preserved.
-    # Worst-case IPC is num_processes × cut_off (e.g. 8 × 200 000 = 1.6 M rows),
-    # which is acceptable for the cut_off values used in practice.
+    # truncated before the merge.
     shard_cut_off: int | None = cut_off
 
-    # Prepare worker arguments
+    # Prepare worker arguments (shard_index is first element)
     worker_args: list[tuple[Any, ...]] = [
-        (corpus_opts, opts, year_range, words_before, words_after, p_show, shard_cut_off) for year_range in year_chunks
+        (i, corpus_opts, opts, year_range, words_before, words_after, p_show, shard_cut_off)
+        for i, year_range in enumerate(year_chunks)
     ]
 
-    # Run queries in parallel
+    # Run queries in parallel, collecting results as they complete
+    results: dict[int, pd.DataFrame] = {}
     with mp.Pool(processes=num_processes) as pool:
-        results: list[pd.DataFrame] = pool.map(kwic_worker, worker_args)
+        for shard_index, df in pool.imap_unordered(kwic_worker, worker_args):
+            results[shard_index] = df
+            if on_shard_complete is not None:
+                on_shard_complete(shard_index, df)
+
+    # Reconstruct in submission order for the combined return value
+    ordered_results = [results[i] for i in sorted(results.keys())]
 
     # Combine results
-    if not results or all(len(df) == 0 for df in results):
+    if not ordered_results or all(len(df) == 0 for df in ordered_results):
         return empty_kwic(p_show)
 
-    # Concatenate all non-empty results
-    non_empty_results: list[pd.DataFrame] = [df for df in results if len(df) > 0]
+    non_empty_results: list[pd.DataFrame] = [df for df in ordered_results if len(df) > 0]
     if not non_empty_results:
         return empty_kwic(p_show)
 
@@ -140,6 +154,6 @@ def execute_kwic_multiprocess(
 
     # Apply cut_off if specified
     if cut_off is not None and len(combined) > cut_off:
-        combined: pd.DataFrame = combined.iloc[:cut_off]
+        combined = combined.iloc[:cut_off]
 
     return combined

--- a/api_swedeb/core/kwic/simple.py
+++ b/api_swedeb/core/kwic/simple.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from typing import Any, Literal
 
 import ccc
@@ -29,12 +30,6 @@ S_ATTR_RENAMES: dict[str, str] = {
 }
 
 
-KWIC_REGISTRY: dict[str, Any] = {
-    "singleprocess": execute_kwic_singleprocess,
-    "multiprocess": execute_kwic_multiprocess,
-}
-
-
 def kwic(  # pylint: disable=too-many-arguments
     corpus: ccc.Corpus | CorpusCreateOpts,
     opts: dict[str, Any] | list[dict[str, Any]],
@@ -45,6 +40,8 @@ def kwic(  # pylint: disable=too-many-arguments
     cut_off: int | None = None,
     use_multiprocessing: bool = False,
     num_processes: int | None = None,
+    on_shards_total: Callable[[int], None] | None = None,
+    on_shard_complete: Callable[[int, pd.DataFrame], None] | None = None,
 ) -> pd.DataFrame:
     """Computes n-grams from a corpus segments that contains a keyword specified in opts.
 
@@ -57,20 +54,47 @@ def kwic(  # pylint: disable=too-many-arguments
         cut_off (int, optional): Threshold of number of hits. Defaults to None (unlimited).
         use_multiprocessing (bool, optional): Whether to use multiprocessing. Defaults to False.
         num_processes (int, optional): Number of processes to use. Defaults to CPU count.
+        on_shards_total: Optional callback fired once with the total shard count.
+        on_shard_complete: Optional callback fired per shard with (shard_index, normalized_df).
     Returns:
         pd.DataFrame: dataframe with index speech_id and columns left_word, node_word, right_word.
     """
     kwic_key: str = "multiprocess" if use_multiprocessing else "singleprocess"
     logger.info(f"Using KWIC {kwic_key}ing method.")
-    kwic_data: pd.DataFrame = KWIC_REGISTRY[kwic_key](
-        corpus=corpus,
-        opts=opts,
-        words_before=words_before,
-        words_after=words_after,
-        p_show=p_show,
-        cut_off=cut_off,
-        num_processes=num_processes,
-    )
+
+    # Wrap the shard callback to apply normalize_kwic_df before forwarding
+    wrapped_shard_callback: Callable[[int, pd.DataFrame], None] | None = None
+    if on_shard_complete is not None and use_multiprocessing:
+        _p_show = p_show
+
+        def _normalize_and_forward(shard_index: int, raw_df: pd.DataFrame) -> None:
+            normalized = normalize_kwic_df(raw_df, lexical_form=_p_show)
+            on_shard_complete(shard_index, normalized)
+
+        wrapped_shard_callback = _normalize_and_forward
+
+    if use_multiprocessing:
+        kwic_data = execute_kwic_multiprocess(
+            corpus=corpus,
+            opts=opts,
+            words_before=words_before,
+            words_after=words_after,
+            p_show=p_show,
+            cut_off=cut_off,
+            num_processes=num_processes,
+            on_shards_total=on_shards_total,
+            on_shard_complete=wrapped_shard_callback,
+        )
+    else:
+        kwic_data = execute_kwic_singleprocess(
+            corpus=corpus,
+            opts=opts,
+            words_before=words_before,
+            words_after=words_after,
+            p_show=p_show,
+            cut_off=cut_off,
+        )
+
     # FIXME: Temporary fix to ensure consistent column naming, but why not use S_ATTR_RENAMES?
     kwic_data = normalize_kwic_df(kwic_data, lexical_form=p_show)
     return kwic_data
@@ -87,6 +111,8 @@ def kwic_with_decode(  # pylint: disable=too-many-arguments
     cut_off: int | None = 200000,
     use_multiprocessing: bool = False,
     num_processes: int | None = None,
+    on_shards_total: Callable[[int], None] | None = None,
+    on_shard_complete: Callable[[int, pd.DataFrame], None] | None = None,
 ) -> pd.DataFrame:
     """Compute KWIC with decoded speech metadata from the prebuilt speech_index.
 
@@ -105,9 +131,29 @@ def kwic_with_decode(  # pylint: disable=too-many-arguments
         cut_off: Maximum hits to return. Defaults to 200000.
         use_multiprocessing: Whether to use multiprocessing. Defaults to False.
         num_processes: Number of processes to use. Defaults to CPU count.
+        on_shards_total: Optional callback fired once with the total shard count.
+        on_shard_complete: Optional callback fired per completed shard with
+            (shard_index, decoded_df) where decoded_df has had the speech index
+            joined and ``speech_id`` column added.
     Returns:
         pd.DataFrame: KWIC results with decoded metadata.
     """
+    # Wrap the shard callback to apply the speech-index join before forwarding
+    wrapped_shard_callback: Callable[[int, pd.DataFrame], None] | None = None
+    if on_shard_complete is not None and use_multiprocessing:
+        _prebuilt = prebuilt_speech_index
+
+        def _join_and_forward(shard_index: int, normalized_df: pd.DataFrame) -> None:
+            if normalized_df.empty:
+                on_shard_complete(shard_index, normalized_df)
+                return
+            joined = normalized_df.join(_prebuilt, how="left")
+            joined.index.name = "speech_id"
+            joined["speech_id"] = joined.index
+            on_shard_complete(shard_index, joined)
+
+        wrapped_shard_callback = _join_and_forward
+
     kwic_data: pd.DataFrame = kwic(
         corpus,
         opts,
@@ -117,6 +163,8 @@ def kwic_with_decode(  # pylint: disable=too-many-arguments
         cut_off=cut_off,
         use_multiprocessing=use_multiprocessing,
         num_processes=num_processes,
+        on_shards_total=on_shards_total,
+        on_shard_complete=wrapped_shard_callback,
     )
     if kwic_data.empty:
         return kwic_data

--- a/api_swedeb/schemas/bulk_archive_schema.py
+++ b/api_swedeb/schemas/bulk_archive_schema.py
@@ -50,7 +50,7 @@ class ArchivePrepareResponse(BaseModel):
 
 class ArchiveTicketStatus(BaseModel):
     archive_ticket_id: str
-    status: Literal["pending", "ready", "error"]
+    status: Literal["pending", "partial", "ready", "error"]
     source_ticket_id: str | None = None
     archive_format: str | None = None
     speech_count: int | None = None

--- a/api_swedeb/schemas/kwic_schema.py
+++ b/api_swedeb/schemas/kwic_schema.py
@@ -50,7 +50,10 @@ class KWICQueryRequest(BaseModel):
     lemmatized: bool = True
     words_before: int = 2
     words_after: int = 2
-    cut_off: int | None = Field(default_factory=_default_cut_off)
+    cut_off: int | None = Field(
+        default_factory=_default_cut_off,
+        description="Deprecated: ignored by the ticket pipeline in Phase 3. Retained for backward compatibility.",
+    )
     filters: KWICFilterRequest = Field(default_factory=KWICFilterRequest)
 
 
@@ -62,10 +65,12 @@ class KWICTicketAccepted(BaseModel):
 
 class KWICTicketStatus(BaseModel):
     ticket_id: str
-    status: Literal["pending", "ready", "error"]
+    status: Literal["pending", "partial", "ready", "error"]
     total_hits: int | None = None
     error: str | None = None
     expires_at: datetime
+    shards_complete: int = 0
+    shards_total: int = 0
 
 
 class KWICTicketSortBy(str, Enum):
@@ -81,16 +86,14 @@ class KWICTicketSortBy(str, Enum):
 
 class KWICPageResult(BaseModel):
     ticket_id: str
-    status: Literal["ready"]
+    status: Literal["partial", "ready", "error"]
     page: int
     page_size: int
     total_hits: int
     total_pages: int
-    display_limited: bool = Field(False, description="True when total_hits is at or above the large-result threshold")
-    display_limit: int | None = Field(
-        None, description="Maximum rows navigable via pagination when display_limited is True"
-    )
     expires_at: datetime
+    shards_complete: int = 0
+    shards_total: int = 0
     kwic_list: list[KeywordInContextItem]
 
 

--- a/api_swedeb/schemas/speeches_schema.py
+++ b/api_swedeb/schemas/speeches_schema.py
@@ -46,7 +46,7 @@ class SpeechesTicketAccepted(BaseModel):
 
 class SpeechesTicketStatus(BaseModel):
     ticket_id: str
-    status: Literal["pending", "ready", "error"]
+    status: Literal["pending", "partial", "ready", "error"]
     total_hits: int | None = None
     error: str | None = None
     expires_at: datetime

--- a/api_swedeb/schemas/word_trends_schema.py
+++ b/api_swedeb/schemas/word_trends_schema.py
@@ -56,7 +56,7 @@ class WordTrendSpeechesTicketAccepted(BaseModel):
 
 class WordTrendSpeechesTicketStatus(BaseModel):
     ticket_id: str
-    status: Literal["pending", "ready", "error"]
+    status: Literal["pending", "partial", "ready", "error"]
     total_hits: int | None = None
     error: str | None = None
     expires_at: datetime

--- a/config/config.yml
+++ b/config/config.yml
@@ -76,8 +76,7 @@ kwic:
   use_multiprocessing: true  # Enabled when the current process may safely spawn child workers
   num_processes: 8
   cut_off: 200000             # Maximum concordance hits fetched from CWB per query
-  large_result_threshold: 10000   # Total hits at or above this value trigger the display cap
-  large_result_display_limit: 1000  # Maximum rows shown in the table when the cap is active
+  download_wait_timeout_s: 300  # Seconds to wait for READY before download endpoint returns 503
 
 celery:
   broker_url: redis://redis:6379/0

--- a/docs/proposals/progressive-kwic-loading.md
+++ b/docs/proposals/progressive-kwic-loading.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-- Proposed feature
+- ~~Proposed feature~~ **Implemented** (Phase 1 ✅, Phase 2 ✅, Phase 3 ✅)
 - Scope: backend (result store, ticket service, multiprocess executor, new estimate endpoint) + frontend (KWIC store, table display)
 - Goal: give users hit-count estimates before searching, apply threshold-based display limits transparently, and deliver KWIC results incrementally as corpus shards complete — removing the silent hard cut-off for both display and download
 
@@ -52,39 +52,60 @@
 ### Phase 3 — Progressive shard delivery
 
 **Backend — Result store**
-- [ ] Add `PARTIAL` to `TicketStatus` enum
-- [ ] Add `shards_complete: int` and `shards_total: int` to `TicketMeta`
-- [ ] Add `store_shard(ticket_id, shard_index, df)` to `ResultStore`
-- [ ] Change artifact layout to per-ticket directory (`{ticket_id}/shard_NNNN.feather`)
-- [ ] Write shard files atomically (temp file + rename)
-- [ ] Update `load_artifact` to concatenate available shards during `PARTIAL`
-- [ ] Write `merged.feather` at `READY` for the download path
-- [ ] Update cleanup to delete the per-ticket directory
+- [x] Add `PARTIAL` to `TicketStatus` enum
+- [x] Add `shards_complete: int = 0` and `shards_total: int = 0` to `TicketMeta` (defaults for Redis backward compat)
+- [x] Add `store_shard(ticket_id, shard_index, df)` to `ResultStore`; transition status to `PARTIAL`
+- [x] Change artifact layout to per-ticket directory (`{ticket_id}/shard_NNNN.feather`)
+- [x] Write shard files atomically (temp file + rename)
+- [x] Invalidate `_artifact_cache` entry for the ticket after each `store_shard` call
+- [x] Update `load_artifact` to concatenate available shard files in index order during `PARTIAL`
+- [x] Write merged artifact at `READY`; delete shard directory immediately after merge
+- [x] Update capacity accounting to reserve shard bytes incrementally, not just at `READY`
+- [x] Update cleanup to delete the whole per-ticket directory
+- [x] Update `artifact_path` callers that assume a single flat file
+
+**Backend — State store**
+- [x] Add `increment_shards_complete(ticket_id)` and `set_shards_total(ticket_id, n)` to `TicketStateStore`
+- [x] Add `get_shard_progress(ticket_id)` → `(shards_complete, shards_total)` to `TicketStateStore`
+- [x] Ensure `PARTIAL` is counted in `_artifact_bytes_delta` (capacity accounting)
+- [x] Add `sync_external_partial(ticket_id)` to `ResultStore` for the API process to sync shard progress from Redis
 
 **Backend — Executor**
-- [ ] Change `execute_kwic_multiprocess` to call `store_shard` in `as_completed` loop
-- [ ] Call `store_ready` after all shards are written
-- [ ] Keep single-process path unchanged
+- [x] Replace `Pool.map()` with `Pool.imap_unordered()` in `execute_kwic_multiprocess`
+- [x] Thread `on_shards_total` / `on_shard_complete` callbacks through executor → `kwic()` → `kwic_with_decode()` → `kwic_service.get_kwic()` → `execute_ticket`
+- [x] Call `store_shard` via `on_shard_complete` as each result is yielded
+- [x] Call `store_shards_ready` after all shards are written (multiprocess path)
+- [x] Keep single-process path unchanged (no `PARTIAL` phase; `store_ready` as before)
 
 **Backend — API**
-- [ ] Expose `shards_complete`, `shards_total`, `total_hits` in the status response
-- [ ] Add `estimated_hits` to the ticket-accepted response (computed at submit time)
-- [ ] Update page response to work correctly during `PARTIAL`
-- [ ] Verify download endpoint waits for `READY` before streaming
+- [x] Expose `shards_complete`, `shards_total` in `KWICTicketStatus` and `KWICPageResult` schemas
+- [x] Add `"partial"` to `KWICTicketStatus.status` literal and `KWICPageResult.status` literal
+- [x] Update `_get_celery_page_result` and `_get_page_result_local` to handle `PARTIAL` status
+- [x] Call `sync_external_partial` in `_get_celery_status` when ticket is not yet `READY`
+- [x] Download endpoint blocks-polls until `READY`; returns HTTP 503 on timeout
+- [x] Remove `_display_cap` from `KWICTicketService` (Phase 2 cap retired)
+- [x] Add `download_wait_timeout_s` to `config/config.yml` and `tests/config.yml`; remove Phase 2 keys
 
 **Backend — Tests**
-- [ ] Test `store_shard` writes atomically and advances `shards_complete`
-- [ ] Test `load_artifact` concatenates shards in order during `PARTIAL`
-- [ ] Test `store_ready` produces a `merged.feather` consistent with all shards
-- [ ] Test executor emits `PARTIAL` before `READY`
+- [x] Existing result store and ticket service tests updated for new cache-key tuple format
+- [x] Obsolete `_display_cap` tests removed
+- [x] `kwic_service` call assertion updated for new `on_shards_total` / `on_shard_complete` params
+- [x] Test `store_shard` writes atomically and advances `shards_complete` in both in-memory and Redis state
+- [x] Test `load_artifact` concatenates shards in index order during `PARTIAL`
+- [x] Test `_artifact_cache` is invalidated after `store_shard`
+- [x] Test `store_ready` produces a merged artifact consistent with all shards and deletes shard files
+- [x] Test capacity accounting across incremental shard writes
+- [x] Test executor emits `PARTIAL` before `READY` (via callback simulation in `test_kwic_ticket_service.py`)
 
 **Frontend**
-- [ ] Update `waitForTicketReady` poll loop to continue on `partial`
-- [ ] Render rows progressively as new pages arrive during `PARTIAL`
-- [ ] Show a shard progress bar from `shards_complete / shards_total`
-- [ ] Disable column sort controls during `PARTIAL`; re-enable and re-sort at `READY`
-- [ ] Remove Phase 2 display-limit banner and config key reads
-- [ ] Remove the `cut_off` parameter from request construction
+- [x] Add `shardsComplete`, `shardsTotal`, `isPartial` state to `kwicDataStore.js`
+- [x] Update `waitForTicketReady` poll loop to continue on `partial` status; fire `fetchKwicPage` on each partial update
+- [x] Update `fetchKwicPage` to sync shard state from page response
+- [x] Show a shard progress bar (`q-linear-progress`) in `kwicDataTable.vue` during `PARTIAL`
+- [x] Disable column sort changes during `PARTIAL` in `onRequest`
+- [x] Add `kwicShardProgress` i18n key to both locales (sv + en-US)
+- [x] Remove Phase 2 `display_limited` / `display_limit` from `KWICPageResult` schema and `KWICTicketService`
+- [x] Remove `large_result_threshold` and `large_result_display_limit` config keys
 
 ---
 
@@ -237,9 +258,23 @@ Each shard file is written atomically (write to a `.tmp` sibling, then `rename`)
 
 #### Multiprocess executor changes
 
-`execute_kwic_multiprocess` currently collects all `Future` results with `as_completed` and concatenates at the end. Change it to call `result_store.store_shard(...)` inside the `as_completed` loop as each shard finishes, then call `result_store.store_ready(...)` after all are done.
+`execute_kwic_multiprocess` currently uses `multiprocessing.Pool.map()`, which is fully blocking — no result is returned until every shard finishes. To enable progressive delivery, replace it with `Pool.imap_unordered()`. The shard index is carried inside the worker args tuple (`(shard_index, corpus_opts, opts, year_range, ...)`), so the worker returns `(shard_index, df)` regardless of completion order. `store_shard(ticket_id, shard_index, df)` names each file `shard_NNNN.feather` by that index, and `store_ready` concatenates shard files in index order to produce `merged.feather`, which is identical to the current `Pool.map()` chronological output. Call `result_store.store_shard(ticket_id, shard_index, df)` as each result is yielded, then call `result_store.store_ready(ticket_id)` after all shards are done.
+
+`TICKET_ROW_ID` is assigned on the merged frame only (not per-shard), preserving it as a stable global row ID. Sort controls are disabled during `PARTIAL`; users never see out-of-order rows.
+
+Celery workers run in a separate process with their own `ResultStore` instance. `store_shard` must therefore propagate shard progress to the API process via `TicketStateStore` (Redis) counters, not only to the worker-local in-memory state. The API process reads these counters via a new `sync_external_partial` bridge (see State store changes below).
 
 Single-process execution remains unchanged (one shard = whole corpus, no `PARTIAL` phase). The Phase 2 display limit is retired once Phase 3 ships; the table simply grows as shards arrive.
+
+#### State store changes
+
+Add per-ticket shard counters to `TicketStateStore` (Redis), mirroring the pattern used for `pending_jobs` and `artifact_bytes`:
+
+- `increment_shards_complete(ticket_id)` — called by the worker's `store_shard`; atomically increments a Redis counter keyed to the ticket.
+- `get_shard_progress(ticket_id)` → `(shards_complete, shards_total)` — polled by the API process.
+- `PARTIAL` must **not** be counted as a pending job in `_pending_delta`; update the method to treat only `PENDING` as pending.
+
+Add `sync_external_partial(ticket_id)` to `ResultStore`: reads shard counters from `TicketStateStore` and updates the in-memory `TicketMeta` with the current `shards_complete` / `shards_total` and status `PARTIAL`. Called by the API process on every status or page request when the ticket is not yet `READY`.
 
 #### API changes
 
@@ -290,10 +325,16 @@ Single-process execution remains unchanged (one shard = whole corpus, no `PARTIA
 |---|---|
 | Shard file writes race with page reads | Atomic rename before exposing shard; page reader scans only fully written files |
 | Celery workers write to different filesystems than the API | Already a constraint on the current path; shard files share the same `cache_dir` as the current artifact |
-| `merged.feather` write duplicates disk usage briefly | Acceptable; it is removed along with shards at TTL expiry |
+| `merged.feather` write doubles peak disk usage briefly | Delete shard files immediately after writing `merged.feather`; capacity check accounts for shard bytes incrementally |
 | Sort accuracy during `PARTIAL` | Documented UX limitation; sort disabled until `READY` |
 | `estimated_hits` is inaccurate for lemmatized queries | Show as "~N expected" not as an exact count; null if word not in vocabulary |
 | Single-process path gains no UX benefit | Acceptable; single-process is used only for small / filtered queries where latency is already low |
+| `Pool.map()` is fully blocking; no `as_completed` hook | Switch to `Pool.imap_unordered()` with explicit `shard_index` in worker args tuple; shard files named by index so merge is always chronological |
+| `_artifact_cache` becomes stale during `PARTIAL` | Invalidate the cache entry for the ticket on every `store_shard` call |
+| `PARTIAL` counted as pending job blocks new submissions | `_pending_delta` must treat only `PENDING` as pending; update state-store logic |
+| `TicketMeta` new fields break Redis deserialization of old entries | Add `default=0` to `shards_complete` / `shards_total`; handle missing keys in `get_ticket` dict |
+| Both local and Celery page-result paths need PARTIAL-awareness | Update `_get_celery_page_result` alongside `_get_page_result_local`; do not leave one path behind |
+| `cut_off` still silently truncates CWB output without Phase 3 `cut_off` removal | Explicitly retire `cut_off` from `KWICQueryRequest` and full call chain when Phase 3 ships |
 
 ---
 
@@ -387,3 +428,58 @@ Start with Phase 1 (estimate endpoint) to give users immediate visibility into q
 | `merged.feather` write doubles disk use briefly | Low | Temporary; shard files deleted after merge |
 | Phase 2 display cap needs explicit removal when Phase 3 ships | Low | Remove banner code path and config keys at deployment |
 | Config key `kwic.large_result_threshold` absent on older deployments | Low | Default value of `10000` provided; no migration required |
+| `Pool.map()` is fully blocking — no `as_completed` to hook into | High | Switch to `imap_unordered()` with `shard_index` in the task args tuple; worker returns `(shard_index, df)`; merge at `READY` concatenates in index order, producing the same chronological result as today |
+| Shard progress invisible to API process (cross-process boundary) | High | `TicketStateStore` (Redis) must carry `shards_complete` / `shards_total`; `sync_external_partial` bridges this on every status poll |
+| `_artifact_cache` returns stale data after partial writes | Medium | Invalidate cache on every `store_shard`; cache is fast enough that re-reads are not costly |
+| `PARTIAL` counted as pending blocks new submissions | Medium | One-line fix to `_pending_delta`; must be done alongside `PARTIAL` introduction |
+| Both Celery and local page-result paths need updating | Medium | `_get_celery_page_result` is a parallel code path to `_get_page_result_local`; Phase 3 must handle both |
+| Peak disk doubles when shard files + `merged.feather` coexist | Low | Delete shards immediately after merge rather than at TTL expiry |
+| `cut_off` still limits CWB output if not explicitly retired | Medium | Remove `cut_off` from `KWICQueryRequest` schema and downstream call chain at Phase 3 deployment |
+| Old Redis entries lack `shards_complete` / `shards_total` keys | Low | Default `= 0` in `TicketMeta` dataclass; handle missing keys in state-store deserialization |
+
+---
+
+## Open Questions — Must Resolve Before Implementation Starts
+
+### 1. Executor interface: `imap_unordered` vs `ProcessPoolExecutor` — **Resolved**
+Adopt `Pool.imap_unordered()`. The shard index is carried inside the worker args tuple so each worker returns `(shard_index, df)` regardless of completion order. Shard files are named `shard_NNNN.feather` by that index; `store_ready` concatenates them in index order to produce `merged.feather`, which is identical to the current `Pool.map()` chronological output. `TICKET_ROW_ID` is assigned on the merged frame only, not per shard. Out-of-order delivery is invisible to users because sort controls are disabled during `PARTIAL`; ordering is fully restored at `READY`.
+
+### 2. `shard_total` is known at submission time — how is it passed to the worker? — **Resolved**
+Write `shards_total` inside `execute_kwic_multiprocess`, immediately after `year_chunks = create_year_chunks(...)` and before the pool starts:
+
+```python
+result_store.set_shards_total(ticket_id, len(year_chunks))
+```
+
+`execute_kwic_multiprocess` already needs `result_store` and `ticket_id` passed in for Phase 3 (it calls `store_shard` per result), so this requires no additional parameters. Keeping the write here avoids duplicating chunk-computation logic in `execute_ticket` and ensures `shards_total` is set atomically with the pool size decision.
+
+### 3. Cross-process `store_shard` write path — **Resolved**
+Adopt the pull model. The Celery worker calls `store_shard`, which writes the shard file to the shared `cache_dir` and increments the Redis shard counter via `TicketStateStore`. The API process never receives a push; it calls `sync_external_partial` on every status or page request when the ticket is not yet `READY`, reading `shards_complete` / `shards_total` from Redis and updating its local `TicketMeta`. This mirrors the existing `sync_external_ready` pattern exactly and requires no new IPC mechanism.
+
+### 4. Artifact-cache invalidation strategy — **Resolved**
+Use a version-tagged cache key: `(ticket_id, shards_complete)` instead of plain `ticket_id` for `_artifact_cache`, and `(ticket_id, shards_complete, sort_columns, ascending)` for `_sorted_positions_cache`.
+
+Effect:
+- Within a poll cycle where `shards_complete` has not changed, the cached DataFrame is returned with no re-read.
+- When a new shard arrives and `shards_complete` increments, the next poll uses a new key, triggers exactly one shard-concat read, and caches the result until the next shard completes.
+- Old versioned keys are evicted naturally by the LRU — no explicit invalidation call is needed during `PARTIAL`.
+- At `READY`, `shards_complete == shards_total` stabilises to a fixed value, so the merged artifact is cached under a stable key, identical to today's behaviour.
+
+This approach is also robust to increasing `kwic.num_processes` (= shard count) for better perceived progress: more shards means the progress bar has more steps and the first result appears sooner, but cache churn stays proportional to the number of shards that complete — one re-read per shard, not one per poll. Raising `kwic.num_processes` from 8 (≈20-year chunks) to 16 (≈10-year chunks) is therefore a straightforward UX improvement with no cache penalty.
+
+### 5. Capacity accounting during incremental shard writes — **Resolved**
+Adopt option (a): pre-reserve capacity upfront. When `execute_kwic_multiprocess` calls `set_shards_total`, also reserve an estimated byte budget for the ticket by setting `ticket.artifact_bytes` to a conservative upfront estimate (e.g. `cut_off × estimated_bytes_per_row`, capped at `max_artifact_bytes`). This reservation is checked against `_artifact_bytes_locked()` immediately — if it would exceed store capacity, fail fast with `ResultStoreCapacityError` before any worker process starts. Individual `store_shard` calls do not re-check capacity; they trust the upfront reservation. At `store_ready`, `ticket.artifact_bytes` is updated to the actual `merged.feather` size, releasing any over-reservation.
+
+This is simpler to implement than per-shard checking and keeps the failure mode consistent with the current `store_ready` path. The trade-off is that the reservation may be pessimistic for filtered queries, but the store already uses eviction to reclaim space so brief over-reservation is acceptable.
+
+### 6. `cut_off` retirement scope and timing — **Resolved**
+(a) `KWICQueryRequest.cut_off` is deprecated and ignored at Phase 3 deployment — the field stays in the schema for backward compatibility but is not passed through to the CWB layer. Mark it with a deprecation note in the schema docstring/field description. (b) The deprecated legacy endpoint retains its own hardcoded `cut_off` default (200 000) and is not changed or removed as part of Phase 3. Removal of both the deprecated field and the legacy endpoint is deferred to a future cleanup task.
+
+### 7. Download endpoint behavior during `PARTIAL` — **Resolved**
+The download endpoint polls `result_store.require_ticket(ticket_id)` in a tight sleep loop until status reaches `READY` (or `ERROR`), then streams `merged.feather`. A configurable timeout (e.g. `kwic.download_wait_timeout_s`, default 300 s) terminates the wait with a 503 if the ticket does not reach `READY` in time. This keeps the endpoint simple (no SSE or callback mechanism) and consistent with the existing synchronous streaming path. The frontend should disable the download button and show a spinner while status is `PARTIAL`, surfacing it only once the poll loop confirms `READY`.
+
+### 8. Frontend: how many rows to show per poll during `PARTIAL`? — **Resolved**
+The currently displayed page is stable — a new shard completing does not re-fetch or replace the rows already shown. The frontend holds its current `page` value across polls; only `total_hits` and `total_pages` are updated from each status response. The user can navigate to higher page numbers as they become available. If the user is on page 2 when shard 5 lands, they stay on page 2; the paginator simply gains more pages. This means the backend must serve any valid page number against the concatenated shard data at the time of the request, not just page 1.
+
+### 9. Phase 2 retirement deployment coordination — **Resolved**
+Phase 2 config keys (`kwic.large_result_threshold`, `kwic.large_result_display_limit`) and the frontend `kwicDisplayCapNote` i18n key are removed atomically in the same deployment as Phase 3. This is not left as follow-up debt.

--- a/tests/api_swedeb/api/endpoints/test_tool_router.py
+++ b/tests/api_swedeb/api/endpoints/test_tool_router.py
@@ -6,7 +6,7 @@ import json
 import zipfile
 from datetime import UTC, datetime
 from typing import Literal
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pandas as pd
 import pytest
@@ -745,8 +745,10 @@ class TestWordTrendSpeechesTicketEndpoints:
             (),
             {"status": "ready", "error": None, "manifest_meta": {}, "total_hits": 1, "expires_at": None},
         )()
-        kwic_ticket_service.get_full_artifact.return_value = pd.DataFrame(
-            [{"left_word": "vi", "node_word": "debatt", "right_word": "nu", "speech_id": "i-1"}]
+        kwic_ticket_service.get_full_artifact = AsyncMock(
+            return_value=pd.DataFrame(
+                [{"left_word": "vi", "node_word": "debatt", "right_word": "nu", "speech_id": "i-1"}]
+            )
         )
 
         result = asyncio.run(

--- a/tests/api_swedeb/api/services/test_estimate_hits.py
+++ b/tests/api_swedeb/api/services/test_estimate_hits.py
@@ -164,20 +164,20 @@ class TestEstimateHitsColumnFilters:
         return WordTrendsService(loader=loader)
 
     def test_column_filter_delegates_to_corpus_filter(self):
-        service = self._service_with_filter_side_effect()
-        opts = {"party_id": [1]}
+        service: WordTrendsService = self._service_with_filter_side_effect()
+        opts: dict[str, list[int]] = {"party_id": [1]}
         # After filter → rows 0,1 → klimat = 2+0 = 2
-        result = service.estimate_hits("klimat", opts)
+        result: int | None = service.estimate_hits("klimat", opts)
         assert result == 2
-        service._loader.vectorized_corpus.filter.assert_called_once()
+        service._loader.vectorized_corpus.filter.assert_called_once()  # type: ignore[attr-defined]
 
     def test_year_and_column_filter_combined(self):
         """Year filter applied after corpus.filter reduces rows further."""
-        service = self._service_with_filter_side_effect()
+        service: WordTrendsService = self._service_with_filter_side_effect()
         # party_id filter → rows 0,1 (years 1990, 2000)
         # then year 1990–1990 → row 0 only → klimat = 2
-        opts = {"party_id": [1], "year": {"low": 1990, "high": 1990}}
-        result = service.estimate_hits("klimat", opts)
+        opts: dict[str, object] = {"party_id": [1], "year": {"low": 1990, "high": 1990}}
+        result: int | None = service.estimate_hits("klimat", opts)
         assert result == 2
 
     def test_no_column_filter_does_not_call_corpus_filter(self):

--- a/tests/api_swedeb/api/services/test_kwic_service.py
+++ b/tests/api_swedeb/api/services/test_kwic_service.py
@@ -53,6 +53,8 @@ def test_get_kwic_builds_opts_and_delegates_to_kwic_with_decode():
         cut_off=123,
         use_multiprocessing=True,
         num_processes=4,
+        on_shards_total=None,
+        on_shard_complete=None,
     )
     assert result is expected
 

--- a/tests/api_swedeb/api/services/test_kwic_ticket_service.py
+++ b/tests/api_swedeb/api/services/test_kwic_ticket_service.py
@@ -533,98 +533,85 @@ def _make_df(n: int) -> pd.DataFrame:
     )
 
 
-def test_display_cap_returns_uncapped_when_below_threshold():
-    """_display_cap must not cap when total_hits < threshold."""
-    service = KWICTicketService()
-    from api_swedeb.core.configuration.inject import ConfigStore
+# ---------------------------------------------------------------------------
+# Phase 3 – multiprocess shard delivery integration
+# ---------------------------------------------------------------------------
 
-    store = ConfigStore()
-    store.configure_context(
-        source={"kwic": {"large_result_threshold": 10000, "large_result_display_limit": 1000}},
-        env_prefix=None,
+
+def test_execute_ticket_transitions_through_partial_before_ready(tmp_path) -> None:
+    """execute_ticket emits PARTIAL (via shard callbacks) and then transitions to READY."""
+    store = ResultStore(
+        root_dir=tmp_path,
+        result_ttl_seconds=600,
+        cleanup_interval_seconds=0,
+        max_artifact_bytes=1_000_000,
+        max_pending_jobs=2,
+        max_page_size=200,
     )
-    with patch("api_swedeb.core.configuration.inject.get_config_store", return_value=store):
-        limited, limit, pages = service._display_cap(total_hits=5, total_pages=1, page_size=10)
-
-    assert limited is False
-    assert limit is None
-    assert pages == 1
-
-
-def test_display_cap_returns_capped_when_at_or_above_threshold():
-    """_display_cap must cap total_pages when total_hits >= threshold."""
-    service = KWICTicketService()
-    from api_swedeb.core.configuration.inject import ConfigStore
-
-    store = ConfigStore()
-    store.configure_context(
-        source={"kwic": {"large_result_threshold": 10000, "large_result_display_limit": 100}},
-        env_prefix=None,
-    )
-    with patch("api_swedeb.core.configuration.inject.get_config_store", return_value=store):
-        limited, limit, pages = service._display_cap(total_hits=15_000, total_pages=1500, page_size=10)
-
-    assert limited is True
-    assert limit == 100
-    assert pages == 10  # ceil(100 / 10)
-
-
-def test_get_page_result_propagates_display_limited_flag(tmp_path):
-    """get_page_result must include display_limited/display_limit from _display_cap."""
-    store = _make_store(tmp_path)
-    service = KWICTicketService()
-
     asyncio.run(store.startup())
     try:
-        ticket = store.create_ticket(query_meta={"search": "test"})
-        store.store_ready(ticket.ticket_id, df=_make_df(5))
+        ticket = store.create_ticket(query_meta={"search": "demokrati"})
 
-        with (
-            patch("api_swedeb.api.services.kwic_ticket_service.ConfigValue.resolve", return_value=False),
-            patch.object(service, "_display_cap", return_value=(True, 100, 1)),
-        ):
-            result = service.get_page_result(
+        # Minimal raw KWIC rows that the mapper can transform
+        def _raw_row(i: int) -> dict:
+            return {
+                "left_word": f"left-{i}",
+                "node_word": "demokrati",
+                "right_word": f"right-{i}",
+                "year": 1970 + i,
+                "name": f"Speaker {i}",
+                "party_abbrev": "S",
+                "document_name": f"prot-{1970 + i}--ak--1",
+                "page_number_start": i,
+                "speech_id": f"i-{i}",
+                "wiki_id": f"Q{i}",
+            }
+
+        df_shard_0 = pd.DataFrame([_raw_row(0)])
+        df_shard_1 = pd.DataFrame([_raw_row(1)])
+        combined = pd.concat([df_shard_0, df_shard_1], ignore_index=True)
+
+        status_transitions: list[TicketStatus] = []
+
+        def fake_get_kwic(
+            *,
+            corpus,
+            commons,
+            keywords,
+            lemmatized,
+            words_before,
+            words_after,
+            cut_off,
+            p_show,
+            on_shards_total=None,
+            on_shard_complete=None,
+        ) -> pd.DataFrame:
+            # Simulate the multiprocess path: announce shard total first, then deliver shards.
+            if on_shards_total is not None:
+                on_shards_total(2)
+                status_transitions.append(store.require_ticket(ticket.ticket_id).status)
+            if on_shard_complete is not None:
+                on_shard_complete(0, df_shard_0)
+                on_shard_complete(1, df_shard_1)
+            return combined
+
+        kwic_service = MagicMock()
+        kwic_service.get_kwic.side_effect = fake_get_kwic
+
+        service = KWICTicketService()
+        with patch.object(service, "_create_corpus", return_value=MagicMock()):
+            service.execute_ticket(
                 ticket_id=ticket.ticket_id,
+                request=KWICQueryRequest(search="demokrati"),
+                cwb_opts={"registry_dir": "/tmp/registry", "corpus_name": "CORPUS", "data_dir": "/tmp/data"},
+                kwic_service=kwic_service,
                 result_store=store,
-                page=1,
-                page_size=10,
-                sort_by=None,
-                sort_order=SortOrder.asc,
             )
 
-        assert isinstance(result, KWICPageResult)
-        assert result.display_limited is True
-        assert result.display_limit == 100
-        assert result.total_pages == 1
-    finally:
-        asyncio.run(store.shutdown())
-
-
-def test_get_page_result_propagates_uncapped_flag(tmp_path):
-    """get_page_result must pass display_limited=False through when not capped."""
-    store = _make_store(tmp_path)
-    service = KWICTicketService()
-
-    asyncio.run(store.startup())
-    try:
-        ticket = store.create_ticket(query_meta={"search": "test"})
-        store.store_ready(ticket.ticket_id, df=_make_df(5))
-
-        with (
-            patch("api_swedeb.api.services.kwic_ticket_service.ConfigValue.resolve", return_value=False),
-            patch.object(service, "_display_cap", return_value=(False, None, 1)),
-        ):
-            result = service.get_page_result(
-                ticket_id=ticket.ticket_id,
-                result_store=store,
-                page=1,
-                page_size=10,
-                sort_by=None,
-                sort_order=SortOrder.asc,
-            )
-
-        assert isinstance(result, KWICPageResult)
-        assert result.display_limited is False
-        assert result.display_limit is None
+        final: TicketMeta = store.require_ticket(ticket.ticket_id)
+        assert final.status == TicketStatus.READY
+        assert final.shards_complete == 2
+        assert final.shards_total == 2
+        assert TicketStatus.PARTIAL in status_transitions, "Ticket must pass through PARTIAL before READY"
     finally:
         asyncio.run(store.shutdown())

--- a/tests/api_swedeb/api/services/test_result_store.py
+++ b/tests/api_swedeb/api/services/test_result_store.py
@@ -329,7 +329,10 @@ def test_result_store_evicts_oldest_artifact_cache_entry_when_limit_is_exceeded(
         for ticket in tickets:
             store.load_artifact(ticket.ticket_id)
 
-        assert list(store._artifact_cache.keys()) == [tickets[1].ticket_id, tickets[2].ticket_id]
+        assert list(store._artifact_cache.keys()) == [
+            (tickets[1].ticket_id, 0),
+            (tickets[2].ticket_id, 0),
+        ]
     finally:
         asyncio.run(store.shutdown())
 
@@ -366,7 +369,7 @@ def test_result_store_evicts_oldest_sorted_positions_cache_entry_when_limit_is_e
         store.get_sorted_positions(ticket.ticket_id, sort_columns=second_key, ascending=(True, True))
         store.get_sorted_positions(ticket.ticket_id, sort_columns=third_key, ascending=(True, True))
 
-        cached_sort_keys = [cache_key[1] for cache_key in store._sorted_positions_cache.keys()]
+        cached_sort_keys = [cache_key[2] for cache_key in store._sorted_positions_cache.keys()]
         assert cached_sort_keys == [second_key, third_key]
     finally:
         asyncio.run(store.shutdown())
@@ -906,5 +909,174 @@ def test_cleanup_removes_ticket_at_absolute_cap(tmp_path) -> None:
 
         store.cleanup_expired()
         assert store.get_ticket(ticket.ticket_id) is None
+    finally:
+        asyncio.run(store.shutdown())
+
+
+# ---------------------------------------------------------------------------
+# Phase 3 – shard delivery tests
+# ---------------------------------------------------------------------------
+
+
+def test_store_shard_writes_file_and_advances_shards_complete(tmp_path) -> None:
+    """store_shard writes a feather file per shard and increments shards_complete in ticket state."""
+    store = ResultStore(
+        root_dir=tmp_path,
+        result_ttl_seconds=600,
+        cleanup_interval_seconds=0,
+        max_artifact_bytes=1_000_000,
+        max_pending_jobs=4,
+        max_page_size=200,
+    )
+    asyncio.run(store.startup())
+    try:
+        ticket = store.create_ticket(query_meta={"search": "test"})
+        store.set_shards_total(ticket.ticket_id, n=3)
+
+        df0 = pd.DataFrame([{"node_word": "a", "year": 1970}])
+        df1 = pd.DataFrame([{"node_word": "b", "year": 1971}])
+
+        meta_after_0 = store.store_shard(ticket.ticket_id, shard_index=0, df=df0)
+        assert meta_after_0.status == TicketStatus.PARTIAL
+        assert meta_after_0.shards_complete == 1
+        assert meta_after_0.shards_total == 3
+        assert meta_after_0.total_hits == 1
+        assert store._shard_path(ticket.ticket_id, 0).exists()
+
+        meta_after_1 = store.store_shard(ticket.ticket_id, shard_index=1, df=df1)
+        assert meta_after_1.shards_complete == 2
+        assert meta_after_1.total_hits == 2
+        assert store._shard_path(ticket.ticket_id, 1).exists()
+
+        # require_ticket must reflect the latest shard count
+        live = store.require_ticket(ticket.ticket_id)
+        assert live.shards_complete == 2
+        assert live.shards_total == 3
+    finally:
+        asyncio.run(store.shutdown())
+
+
+def test_load_artifact_concatenates_shards_in_index_order_during_partial(tmp_path) -> None:
+    """load_artifact during PARTIAL returns shards concatenated in shard-index order."""
+    store = ResultStore(
+        root_dir=tmp_path,
+        result_ttl_seconds=600,
+        cleanup_interval_seconds=0,
+        max_artifact_bytes=1_000_000,
+        max_pending_jobs=4,
+        max_page_size=200,
+    )
+    asyncio.run(store.startup())
+    try:
+        ticket = store.create_ticket(query_meta={"search": "test"})
+        store.set_shards_total(ticket.ticket_id, n=3)
+
+        # Write shards out of arrival order; load_artifact must sort by filename (index order).
+        store.store_shard(ticket.ticket_id, shard_index=2, df=pd.DataFrame([{"node_word": "c", "year": 1972}]))
+        store.store_shard(ticket.ticket_id, shard_index=0, df=pd.DataFrame([{"node_word": "a", "year": 1970}]))
+        store.store_shard(ticket.ticket_id, shard_index=1, df=pd.DataFrame([{"node_word": "b", "year": 1971}]))
+
+        loaded = store.load_artifact(ticket.ticket_id)
+
+        assert list(loaded["node_word"]) == ["a", "b", "c"]
+        assert list(loaded["year"]) == [1970, 1971, 1972]
+    finally:
+        asyncio.run(store.shutdown())
+
+
+def test_store_shard_invalidates_artifact_cache(tmp_path) -> None:
+    """Each store_shard call must evict any cached PARTIAL artifact for the ticket."""
+    store = ResultStore(
+        root_dir=tmp_path,
+        result_ttl_seconds=600,
+        cleanup_interval_seconds=0,
+        max_artifact_bytes=1_000_000,
+        max_pending_jobs=4,
+        max_page_size=200,
+    )
+    asyncio.run(store.startup())
+    try:
+        ticket = store.create_ticket(query_meta={"search": "test"})
+        store.set_shards_total(ticket.ticket_id, n=2)
+        store.store_shard(ticket.ticket_id, shard_index=0, df=pd.DataFrame([{"node_word": "a"}]))
+
+        # Populate cache: key is (ticket_id, shards_complete==1)
+        store.load_artifact(ticket.ticket_id)
+        ticket_cache_keys_before = [k for k in store._artifact_cache if k[0] == ticket.ticket_id]
+        assert len(ticket_cache_keys_before) == 1
+
+        # Second shard must evict the previous cache entry
+        store.store_shard(ticket.ticket_id, shard_index=1, df=pd.DataFrame([{"node_word": "b"}]))
+
+        ticket_cache_keys_after = [k for k in store._artifact_cache if k[0] == ticket.ticket_id]
+        assert ticket_cache_keys_after == [], "store_shard must invalidate the cached partial artifact"
+    finally:
+        asyncio.run(store.shutdown())
+
+
+def test_store_shards_ready_merges_shards_transitions_to_ready_and_deletes_shard_dir(tmp_path) -> None:
+    """store_shards_ready produces a merged artifact consistent with all shards and removes the shard directory."""
+    store = ResultStore(
+        root_dir=tmp_path,
+        result_ttl_seconds=600,
+        cleanup_interval_seconds=0,
+        max_artifact_bytes=1_000_000,
+        max_pending_jobs=4,
+        max_page_size=200,
+    )
+    asyncio.run(store.startup())
+    try:
+        ticket = store.create_ticket(query_meta={"search": "test"})
+        store.set_shards_total(ticket.ticket_id, n=2)
+        store.store_shard(ticket.ticket_id, shard_index=0, df=pd.DataFrame([{"node_word": "a", "year": 1970}]))
+        store.store_shard(ticket.ticket_id, shard_index=1, df=pd.DataFrame([{"node_word": "b", "year": 1971}]))
+
+        shard_dir = store._shard_dir(ticket.ticket_id)
+        assert shard_dir.exists()
+
+        ready = store.store_shards_ready(
+            ticket.ticket_id,
+            query_meta={"search": "test"},
+            speech_ids=None,
+            manifest_meta=None,
+        )
+
+        assert ready.status == TicketStatus.READY
+        assert ready.shards_complete == 2
+        assert ready.shards_total == 2
+        assert ready.total_hits == 2
+        assert not shard_dir.exists(), "Shard directory must be deleted after merge"
+        assert ready.artifact_path is not None
+        assert ready.artifact_path.exists()
+
+        merged = store.load_artifact(ticket.ticket_id)
+        assert list(merged["node_word"]) == ["a", "b"]
+    finally:
+        asyncio.run(store.shutdown())
+
+
+def test_set_shards_total_reserved_bytes_blocks_second_ticket_when_capacity_exhausted(tmp_path) -> None:
+    """Reserved bytes from a PARTIAL ticket count toward capacity; a second large reservation must fail."""
+    store = ResultStore(
+        root_dir=tmp_path,
+        result_ttl_seconds=600,
+        cleanup_interval_seconds=0,
+        max_artifact_bytes=1_000_000,
+        max_pending_jobs=4,
+        max_page_size=200,
+    )
+    asyncio.run(store.startup())
+    try:
+        first = store.create_ticket(query_meta={"search": "a"})
+        store.set_shards_total(first.ticket_id, n=3, reserved_bytes=900_000)
+
+        # After reservation, the first ticket holds most of the available capacity.
+        first_meta = store.require_ticket(first.ticket_id)
+        assert first_meta.status == TicketStatus.PARTIAL
+        assert first_meta.artifact_bytes == 900_000
+
+        second = store.create_ticket(query_meta={"search": "b"})
+        with pytest.raises(ResultStoreCapacityError):
+            store.set_shards_total(second.ticket_id, n=1, reserved_bytes=200_000)
     finally:
         asyncio.run(store.shutdown())

--- a/tests/config.yml
+++ b/tests/config.yml
@@ -36,8 +36,7 @@ kwic:
   use_multiprocessing: true
   num_processes: 8
   cut_off: 200000
-  large_result_threshold: 10000
-  large_result_display_limit: 1000
+  download_wait_timeout_s: 300
 
 celery:
   broker_url: redis://redis:6379/0

--- a/tests/integration/test_kwic_core.py
+++ b/tests/integration/test_kwic_core.py
@@ -1,4 +1,4 @@
-from typing import Any, Literal
+from typing import Any, Literal, cast
 from unittest.mock import patch
 
 import ccc
@@ -505,12 +505,13 @@ def test_kwic_worker(corpus_opts: CorpusCreateOpts):
         "value": "debatt",
     }
     year_range = (1970, 1975)
-    args = (corpus_opts, opts, year_range, 3, 3, "word", 50)
+    args = (1, corpus_opts, opts, year_range, 3, 3, "word", 50)
 
-    result = kwic_worker(args)
+    result: tuple[int, pd.DataFrame] = kwic_worker(args)
 
-    assert isinstance(result, pd.DataFrame)
-    assert result.index.name == "speech_id"
+    assert isinstance(result, tuple)
+    assert isinstance(result[1], pd.DataFrame)
+    assert cast(pd.DataFrame, result[1]).index.name == "speech_id"
 
 
 def test_execute_kwic_multiprocess_basic(corpus_opts: CorpusCreateOpts):


### PR DESCRIPTION
Closes #361

- Add PARTIAL status and per-ticket shard artifact layout to ResultStore
- Write shards atomically; load_artifact concatenates in index order during PARTIAL
- Merge all shards into single artifact at READY; delete shard directory
- Add increment_shards_complete, set_shards_total, get_shard_progress, and sync_external_partial to TicketStateStore
- Replace Pool.map() with Pool.imap_unordered() in multiprocess executor
- Thread on_shards_total/on_shard_complete callbacks through executor chain
- Expose shards_complete, shards_total, and partial status in schemas
- Download endpoint polls until READY; returns 503 on timeout
- Remove Phase 2 display-cap config keys; add download_wait_timeout_s
- Update and extend result store and ticket service tests for new layout