### PR TITLE
Decouple num_shards from num_processes for improved KWIC partitioning

### DIFF
--- a/api_swedeb/api/services/kwic_service.py
+++ b/api_swedeb/api/services/kwic_service.py
@@ -46,6 +46,7 @@ class KWICService:
         cut_off: int | None = 200000,
         use_multiprocessing: bool | None = None,  # None = read from config
         n_processes: int | None = None,
+        n_shards: int | None = None,
         on_shards_total: Callable[[int], None] | None = None,
         on_shard_complete: Callable[[int, pd.DataFrame], None] | None = None,
     ) -> pd.DataFrame:
@@ -62,6 +63,7 @@ class KWICService:
             cut_off: Maximum number of hits to return
             use_multiprocessing: Whether to use multiprocessing (overrides config if not None)
             n_processes: Number of processes for multiprocessing (overrides config if not None)
+            n_shards: Year-range partitions (overrides config if not None; defaults to n_processes)
             on_shards_total: Optional callback fired once with total shard count (multiprocess only).
             on_shard_complete: Optional callback fired per decoded shard (multiprocess only).
 
@@ -89,6 +91,7 @@ class KWICService:
             cut_off=cut_off,
             use_multiprocessing=resolved_use_multiprocessing,
             num_processes=n_processes or ConfigValue("kwic.num_processes", default=8).resolve(),
+            num_shards=n_shards if n_shards is not None else ConfigValue("kwic.num_shards", default=None).resolve(),
             on_shards_total=on_shards_total,
             on_shard_complete=on_shard_complete,
         )

--- a/api_swedeb/api/services/speeches_ticket_service.py
+++ b/api_swedeb/api/services/speeches_ticket_service.py
@@ -238,6 +238,7 @@ class SpeechesTicketService:
                 sort_columns, ascending = self._sort_spec(sort_by=sort_by, sort_order=sort_order)
                 sorted_positions = result_store.get_sorted_positions(
                     ticket_id,
+                    data=data,
                     sort_columns=sort_columns,
                     ascending=ascending,
                 )

--- a/api_swedeb/api/services/word_trend_speeches_ticket_service.py
+++ b/api_swedeb/api/services/word_trend_speeches_ticket_service.py
@@ -282,6 +282,7 @@ class WordTrendSpeechesTicketService:
             sort_columns, ascending = self._sort_spec(sort_by=sort_by, sort_order=sort_order)
             sorted_positions = result_store.get_sorted_positions(
                 ticket_id,
+                data=data,
                 sort_columns=sort_columns,
                 ascending=ascending,
             )

--- a/api_swedeb/core/kwic/multiprocess.py
+++ b/api_swedeb/core/kwic/multiprocess.py
@@ -80,6 +80,7 @@ def execute_kwic_multiprocess(
     p_show: Literal["word", "lemma"],
     cut_off: int | None,
     num_processes: int | None,
+    num_shards: int | None = None,
     on_shards_total: Callable[[int], None] | None = None,
     on_shard_complete: Callable[[int, pd.DataFrame], None] | None = None,
 ) -> pd.DataFrame:
@@ -92,7 +93,11 @@ def execute_kwic_multiprocess(
         words_after: Number of words after match
         p_show: What to display ('word' or 'lemma')
         cut_off: Maximum number of results
-        num_processes: Number of processes to use (None = CPU count)
+        num_processes: Number of parallel worker processes (pool size).  None = CPU count.
+        num_shards: Number of year-range partitions to divide the corpus into.
+                    When None, defaults to ``num_processes`` (previous behaviour).
+                    Setting this higher than ``num_processes`` enables finer-grained
+                    partitioning with load balancing across workers.
         on_shards_total: Optional callback invoked once with the total shard count
                          before the pool starts.  Used by the ticket service to
                          pre-register shard metadata.
@@ -106,6 +111,10 @@ def execute_kwic_multiprocess(
     if num_processes is None:
         num_processes = mp.cpu_count()
 
+    # num_shards controls partitioning granularity; defaults to num_processes
+    # when not set so that existing behaviour is preserved.
+    effective_num_shards: int = num_shards if num_shards is not None else num_processes
+
     corpus_opts: CorpusCreateOpts = CorpusCreateOpts.to_opts(corpus)
 
     default_min: int = ConfigValue("kwic.default_min_year", default=1867).resolve()
@@ -114,8 +123,8 @@ def execute_kwic_multiprocess(
     # Extract year range from opts or use defaults
     min_year, max_year = extract_year_range(opts, default_min=default_min, default_max=default_max)
 
-    # Create year chunks
-    year_chunks: list[tuple[int, int]] = create_year_chunks(min_year, max_year, num_processes)
+    # Create year chunks — partitioning driven by num_shards, parallelism by num_processes
+    year_chunks: list[tuple[int, int]] = create_year_chunks(min_year, max_year, effective_num_shards)
 
     # Notify caller of total shard count before pool starts (for capacity reservation)
     if on_shards_total is not None:

--- a/api_swedeb/core/kwic/simple.py
+++ b/api_swedeb/core/kwic/simple.py
@@ -40,6 +40,7 @@ def kwic(  # pylint: disable=too-many-arguments
     cut_off: int | None = None,
     use_multiprocessing: bool = False,
     num_processes: int | None = None,
+    num_shards: int | None = None,
     on_shards_total: Callable[[int], None] | None = None,
     on_shard_complete: Callable[[int, pd.DataFrame], None] | None = None,
 ) -> pd.DataFrame:
@@ -53,7 +54,8 @@ def kwic(  # pylint: disable=too-many-arguments
         p_show (Literal['word', 'lemma'], optional): Target type to display. Defaults to "word".
         cut_off (int, optional): Threshold of number of hits. Defaults to None (unlimited).
         use_multiprocessing (bool, optional): Whether to use multiprocessing. Defaults to False.
-        num_processes (int, optional): Number of processes to use. Defaults to CPU count.
+        num_processes (int, optional): Number of parallel workers (pool size). Defaults to CPU count.
+        num_shards (int, optional): Year-range partitions. Defaults to num_processes when None.
         on_shards_total: Optional callback fired once with the total shard count.
         on_shard_complete: Optional callback fired per shard with (shard_index, normalized_df).
     Returns:
@@ -82,6 +84,7 @@ def kwic(  # pylint: disable=too-many-arguments
             p_show=p_show,
             cut_off=cut_off,
             num_processes=num_processes,
+            num_shards=num_shards,
             on_shards_total=on_shards_total,
             on_shard_complete=wrapped_shard_callback,
         )
@@ -111,6 +114,7 @@ def kwic_with_decode(  # pylint: disable=too-many-arguments
     cut_off: int | None = 200000,
     use_multiprocessing: bool = False,
     num_processes: int | None = None,
+    num_shards: int | None = None,
     on_shards_total: Callable[[int], None] | None = None,
     on_shard_complete: Callable[[int, pd.DataFrame], None] | None = None,
 ) -> pd.DataFrame:
@@ -130,7 +134,8 @@ def kwic_with_decode(  # pylint: disable=too-many-arguments
         p_show: What to display, ``word`` or ``lemma``. Defaults to "word".
         cut_off: Maximum hits to return. Defaults to 200000.
         use_multiprocessing: Whether to use multiprocessing. Defaults to False.
-        num_processes: Number of processes to use. Defaults to CPU count.
+        num_processes: Number of parallel workers (pool size). Defaults to CPU count.
+        num_shards: Year-range partitions. Defaults to num_processes when None.
         on_shards_total: Optional callback fired once with the total shard count.
         on_shard_complete: Optional callback fired per completed shard with
             (shard_index, decoded_df) where decoded_df has had the speech index
@@ -163,6 +168,7 @@ def kwic_with_decode(  # pylint: disable=too-many-arguments
         cut_off=cut_off,
         use_multiprocessing=use_multiprocessing,
         num_processes=num_processes,
+        num_shards=num_shards,
         on_shards_total=on_shards_total,
         on_shard_complete=wrapped_shard_callback,
     )

--- a/config/config.yml
+++ b/config/config.yml
@@ -75,6 +75,7 @@ startup:
 kwic:
   use_multiprocessing: true     # Enabled when the current process may safely spawn child workers
   num_processes: 8
+  num_shards: 24                # Year-range partitions; must be >= num_processes for load balancing
   cut_off: 500000               # Maximum concordance hits fetched from CWB per query
   download_wait_timeout_s: 300  # Seconds to wait for READY before download endpoint returns 503
 

--- a/tests/config.yml
+++ b/tests/config.yml
@@ -82,6 +82,7 @@ startup:
 kwic:
   use_multiprocessing: true
   num_processes: 8
+  num_shards: 24
   cut_off: 200000
   download_wait_timeout_s: 300
 


### PR DESCRIPTION
Enhance the KWIC multiprocess functionality by introducing a separate `num_shards` parameter, allowing for finer year-range partitioning independent of the number of processes. This change improves load balancing and performance. Additionally, update the frontend to prevent overriding the backend's cut-off configuration.

Fixes #364